### PR TITLE
do not generate emails with dots

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -11,7 +11,7 @@ var random = require('../util/random'),
     formats = require('../util/formats');
 
 var regexps = {
-  email: '[a-zA-Z\\d][a-zA-Z\\d.-]{1,13}[a-zA-Z\\d]@{hostname}',
+  email: '[a-zA-Z\\d][a-zA-Z\\d-]{1,13}[a-zA-Z\\d]@{hostname}',
   hostname: '[a-zA-Z]{1,33}\\.[a-z]{2,4}',
   ipv6: '[abcdef\\d]{4}(:[abcdef\\d]{4}){7}',
   uri: '[a-zA-Z\\d_][\\w\\\/\\d_-]{1,40}'


### PR DESCRIPTION
If you generate dots in the email its possible to generate
    an email which contains consecutative dots

> No leading, trailing, or consecutive dots

Your current regex gaurds against leading & trailing dots
    however you do not gaurd against consecutive dots.

Note that consecutive dots are random and rare but
    do fail my tests

cc @patekektrueke
