### PR TITLE
fix: number-max-min

### DIFF
--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -1,40 +1,41 @@
 'use strict';
 
 var MIN_INTEGER = -100000000,
-    MAX_INTEGER = 100000000;
+    MAX_INTEGER = 100000000,
+    DEFAULT_PRECISION   = .00001;
 
-var string = require('./string'),
-    random = require('../util/random');
+var container = require('../util/container'),
+    string = require('./string');
+
+var faker = container.get('faker');
 
 module.exports = function(value) {
   if (value.faker || value.chance) {
     return string(value);
   }
 
+  var multipleOf = value.multipleOf;
+
   var min = typeof value.minimum === 'undefined' ? MIN_INTEGER : value.minimum,
       max = typeof value.maximum === 'undefined' ? MAX_INTEGER : value.maximum;
 
-  if (value.exclusiveMinimum && value.minimum) {
-    min += 1;
+  var fakerPrecision = multipleOf || DEFAULT_PRECISION;
+
+  if (multipleOf) {
+    max = Math.floor(max / multipleOf) * multipleOf;
+    min = Math.ceil(min / multipleOf) * multipleOf;
   }
 
-  if (value.exclusiveMaximum && value.maximum) {
-    max -= 1;
+
+  if (value.exclusiveMinimum && value.minimum && min === value.minimum) {
+    min += fakerPrecision;
+  }
+  if (value.exclusiveMaximum && value.maximum && max === value.maximum) {
+    max -= fakerPrecision;
   }
 
-  if (value.multipleOf) {
-    var base = random(Math.floor(min / value.multipleOf), Math.floor(max / value.multipleOf)) * value.multipleOf;
-
-    while (base < min) {
-      base += value.multipleOf;
-    }
-
-    return base;
+  if (min > max) {
+    return null;
   }
-
-  if (value.hasPrecision) {
-    return random(false, min, max);
-  }
-
-  return random(Math.random() > 0.5, min, max);
+  return faker.random.number({min: min, max: max, precision: fakerPrecision});
 };

--- a/spec/core/issues/number-min-max.json
+++ b/spec/core/issues/number-min-max.json
@@ -1,0 +1,73 @@
+[
+  {
+    "description": "generated number obeying min/max, 6 times to account for randomn test pass",
+    "tests": [
+      {
+        "description": "should handle one possible value min/max number",
+        "schema": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "hasNot": ".",
+        "type": "number",
+        "valid": true
+      },
+      {
+        "description": "should handle one possible value min/max number",
+        "schema": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "hasNot": ".",
+        "type": "number",
+        "valid": true
+      },
+      {
+        "description": "should handle one possible value min/max number",
+        "schema": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "hasNot": ".",
+        "type": "number",
+        "valid": true
+      },
+      {
+        "description": "should handle one possible value min/max number",
+        "schema": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "hasNot": ".",
+        "type": "number",
+        "valid": true
+      },
+      {
+        "description": "should handle one possible value min/max number",
+        "schema": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "hasNot": ".",
+        "type": "number",
+        "valid": true
+      },
+      {
+        "description": "should handle one possible value min/max number",
+        "schema": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "hasNot": ".",
+        "type": "number",
+        "valid": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
The failing schmea:
```
"schema": {
          "type": "number",
          "minimum": 1,
          "maximum": 1
},
```

In fact any "Number" with a maximum field would occasionally fail.  This is problematic.  