### PR TITLE
separating plain generator functions

### DIFF
--- a/lib/generators/boolean.js
+++ b/lib/generators/boolean.js
@@ -1,0 +1,8 @@
+/**
+ * Generates randomized boolean value.
+ *
+ * @returns {boolean}
+ */
+module.exports = function() {
+  return Math.random() > 0.5;
+};

--- a/lib/generators/null.js
+++ b/lib/generators/null.js
@@ -1,0 +1,8 @@
+/**
+ * Generates null value.
+ *
+ * @returns {null}
+ */
+module.exports = function() {
+  return null;
+};

--- a/lib/generators/words.js
+++ b/lib/generators/words.js
@@ -1,4 +1,4 @@
-var random = require('./random');
+var random = require('./../util/random');
 
 var LIPSUM_WORDS = ('Lorem ipsum dolor sit amet consectetur adipisicing elit sed do eiusmod tempor incididunt ut labore'
   + ' et dolore magna aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea'
@@ -6,6 +6,13 @@ var LIPSUM_WORDS = ('Lorem ipsum dolor sit amet consectetur adipisicing elit sed
   + ' pariatur Excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est'
   + ' laborum').split(' ');
 
+/**
+ * Generates randomized array of single lorem ipsum words.
+ *
+ * @param min
+ * @param max
+ * @returns {Array.<string>}
+ */
 module.exports = function(min, max) {
   var words = random.shuffle(LIPSUM_WORDS),
       length = random(min || 1, Math.min(LIPSUM_WORDS.length, max || min || 5));

--- a/lib/types/boolean.js
+++ b/lib/types/boolean.js
@@ -1,3 +1,0 @@
-module.exports = function() {
-  return Math.random() > 0.5;
-};

--- a/lib/types/null.js
+++ b/lib/types/null.js
@@ -1,3 +1,0 @@
-module.exports = function() {
-  return null;
-};

--- a/lib/types/object.js
+++ b/lib/types/object.js
@@ -1,6 +1,6 @@
 var container = require('../util/container'),
     random = require('../util/random'),
-    words = require('../util/words'),
+    words = require('../generators/words'),
     traverse = require('../util/traverse'),
     hasProps = require('../util/has-props');
 

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -5,7 +5,7 @@ var faker = container.get('faker'),
     RandExp = container.get('randexp'),
     randexp = RandExp.randexp;
 
-var words = require('../util/words'),
+var words = require('../generators/words'),
     random = require('../util/random'),
     formats = require('../util/formats');
 

--- a/lib/util/primitives.js
+++ b/lib/util/primitives.js
@@ -1,9 +1,9 @@
 module.exports = {
+  boolean: require('../generators/boolean'),
+  null: require('../generators/null'),
   array: require('../types/array'),
-  boolean: require('../types/boolean'),
   integer: require('../types/integer'),
   number: require('../types/number'),
-  null: require('../types/null'),
   object: require('../types/object'),
   string: require('../types/string')
 };


### PR DESCRIPTION
I moved the easy plain functions out from the rest of the code to keep it clean. I can see the are just functions and so I made a place for them. The current colution is a little dirty (e.g. `words` in `types` directory?) and not really scalable, if we want to add any more generating elements.

The final solution I think about is to provide `generators` as they are here and - if a type is more complex, just like integer/number - then add a wrapper for basic generators. So all primitives would be a collection of either generators or wrapper generators.

@pateketrueke what is your opinion on that?