### PR TITLE
traverse minor fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+UPCOMING:
+  changes:
+    - faker and chance are not longer required as dependencies
+v0.2.10:
+  date: 2016-02-04
+  changes:
+    - fixed faker/chance as dependencies (before next minor version)
 v0.2.9:
   date: 2016-02-04
   changes:

--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ You can also use standard JSON Schema keywords, e.g. `pattern`:
 }
 ```
 
+**BREAKING CHANGES**
+
+> Since `0.3.0` the `faker` and `chance` dependencies aren't shipped by default,
+> in order to use both generators you MUST install them with `npm install faker chance --save`.
+
 ## Custom formats
 
 Additionally, you can add custom generators for those:

--- a/lib/util/traverse.js
+++ b/lib/util/traverse.js
@@ -1,10 +1,7 @@
 var random = require('./random');
-
 var ParseError = require('./error');
-
 var inferredType = require('./inferred');
-
-var primitives = null;
+var primitives = require('./primitives');
 
 function traverse(obj, path, resolve) {
   resolve(obj);
@@ -56,7 +53,5 @@ function traverse(obj, path, resolve) {
 }
 
 module.exports = function() {
-  primitives = primitives || require('./primitives');
-
   return traverse.apply(null, arguments);
 };

--- a/package.json
+++ b/package.json
@@ -31,16 +31,16 @@
   "bugs": "https://github.com/json-schema-faker/json-schema-faker/issues",
   "license": "MIT",
   "dependencies": {
-    "chance": "^0.8.0",
     "deref": "^0.6.3",
-    "faker": "^3.0.1",
     "randexp": "^0.4.2"
   },
   "devDependencies": {
     "browserify": "^13.0.0",
+    "chance": "^0.8.0",
     "clone": "^1.0.2",
     "codecov": "^1.0.1",
     "eslint": "^1.10.3",
+    "faker": "^3.0.1",
     "fs-extra": "^0.26.5",
     "glob": "^6.0.4",
     "istanbul": "^0.4.2",


### PR DESCRIPTION
I've got a problem with this one, when trying to migrate to typescript...

Some time ago, @presidento has submitted this one d96efbcb853c62d266484c7602cba9a39cd3b845 which I merged in actually. The thing is I don't clearly understand how does this optimization works. Seems likt `primitives` is being caught into the closure only for the first time, when used. But such usage of `require` function is very hacky. And difficult to migrate to TS - which I like - since our current construct is quite unclean. I'm thinking of moving the `require` call to outer module (one level up) to make sure it's just loaded once.

What I'd like to do is just to keep the original optimization, once I'm sure how it works :) and clear the module loading pattern down there. But I'm afraid that my code here removes the optimization, so don't merge it yet... :(