### PR TITLE
Allow custom formats to override built-in ones

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -68,29 +68,38 @@ function generate(value) {
     return gen.apply(contextObject, args);
   }
 
+  var callback = formats(value.format);
+
   switch (value.format) {
     case 'date-time':
-      return new Date(random(0, 100000000000000)).toISOString();
+      if (!callback) {
+        return new Date(random(0, 100000000000000)).toISOString();
+      }
 
     case 'email':
     case 'hostname':
     case 'ipv6':
     case 'uri':
-      return randexp(regexps[value.format]).replace(/\{(\w+)\}/, function(matches, key) {
-        return randexp(regexps[key]);
-      });
+      if (!callback) {
+        return randexp(regexps[value.format]).replace(/\{(\w+)\}/, function(matches, key) {
+          return randexp(regexps[key]);
+        });
+      }
 
     case 'ipv4':
-      return [0, 0, 0, 0].map(function() {
-        return random(0, 255);
-      }).join('.');
+      if (!callback) {
+        return [0, 0, 0, 0].map(function() {
+          return random(0, 255);
+        }).join('.');
+      }
 
     case 'regex':
       // TODO: discuss
-      return '.+?';
+      if (!callback) {
+        return '.+?';
+      }
 
     default:
-      var callback = formats(value.format);
 
       if (typeof callback !== 'function') {
         throw new Error('unknown generator for ' + JSON.stringify(value.format));


### PR DESCRIPTION
Proposal for allowing custom formats such as `email` have priority over built-in ones. #88 