### PR TITLE
fix for exception "value.key.split is not a function"

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -61,7 +61,7 @@ function generate(value) {
     // making jsf break after upgrading from 3.0.1
     var contextObject = value.gen;
     if (value.use === "faker") {
-      var fakerModuleName = value.key.split('.')[0];
+      var fakerModuleName = path.split('.')[0];
       contextObject = value.gen[fakerModuleName];
     }
 


### PR DESCRIPTION
use path instead of value.key since value.key is an object and not a string