### PR TITLE
Falsey defaults

### DIFF
--- a/lib/core/traverse.js
+++ b/lib/core/traverse.js
@@ -26,7 +26,7 @@ function traverse(schema, path, resolve) {
     if (Array.isArray(schema.enum)) {
         return random.pick(schema.enum);
     }
-    if (option('useDefaultValue') && schema.default) {
+    if (option('useDefaultValue') && 'default' in schema) {
         return schema.default;
     }
     // TODO remove the ugly overcome

--- a/spec/schema/core/option/falsey-defaults.json
+++ b/spec/schema/core/option/falsey-defaults.json
@@ -1,0 +1,57 @@
+[
+  {
+    "description": "falsey defaults",
+    "tests": [
+      {
+        "description": "boolean can be false",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        },
+        "equal": false,
+        "require": "core/option/useDefaultValue"
+      },
+      {
+        "description": "number can be 0",
+        "schema": {
+          "type": "number",
+          "default": 0
+        },
+        "equal": 0,
+        "require": "core/option/useDefaultValue"
+      },
+      {
+        "description": "string can be empty",
+        "schema": {
+          "type": "string",
+          "default": ""
+        },
+        "equal": "",
+        "require": "core/option/useDefaultValue"
+      },
+      {
+        "description": "objects can be null",
+        "schema": {
+          "type": "object",
+          "default": null
+        },
+        "equal": null,
+        "require": "core/option/useDefaultValue"
+      },
+      {
+        "description": "array of booleans all being false",
+        "schema": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "items": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "equal": [ false, false, false, false, false ],
+        "require": "core/option/useDefaultValue"
+      }
+    ]
+  }
+]

--- a/spec/schema/main-spec.coffee
+++ b/spec/schema/main-spec.coffee
@@ -55,7 +55,7 @@ tryTest = (test, refs, schema) ->
         #{JSON.stringify(schema, null, 2)}
       """
 
-  if test.equal
+  if "equal" of test
     expect(sample).toEqual test.equal
 
 glob.sync("#{__dirname}/**/*.json").forEach (file) ->

--- a/ts/core/traverse.ts
+++ b/ts/core/traverse.ts
@@ -33,7 +33,7 @@ function traverse(schema: JsonSchema, path: SchemaPath, resolve: Function) {
     return random.pick(schema.enum);
   }
 
-  if (option('useDefaultValue') && schema.default) {
+  if (option('useDefaultValue') && 'default' in schema) {
     return schema.default;
   }
 


### PR DESCRIPTION
I fixed the same issue in 3 different languages in one project, that has to be a first ;)

On a serious note though, I think the ```in``` operator would be the correct choice here as it only checks the presents of a key and does't actually get the value.