### PR TITLE
Allow limiting array maxItems and string maxLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ You may define following options for `jsf` that alter its behavior:
 
 - `failOnInvalidTypes`: boolean - don't throw exception when invalid type passed
 - `defaultInvalidTypeProduct`: - default value generated for a schema with invalid type (works only if `failOnInvalidTypes` is set to `false`)
+- `maxItems`: number - Configure a maximum amount of items to generate in an array. This will override the maximum items found inside a JSON Schema.
+- `maxLength`: number - Configure a maximum length to allow generating strings for. This will override the maximum length found inside a JSON Schema.
 
 Set options just as below:
 

--- a/lib/class/OptionRegistry.js
+++ b/lib/class/OptionRegistry.js
@@ -15,6 +15,8 @@ var OptionRegistry = (function (_super) {
         this.data['failOnInvalidTypes'] = true;
         this.data['defaultInvalidTypeProduct'] = null;
         this.data['useDefaultValue'] = false;
+        this.data['maxItems'] = null;
+        this.data['maxLength'] = null;
     }
     return OptionRegistry;
 }(Registry));

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -2,6 +2,7 @@
 var random = require('../core/random');
 var utils = require('../core/utils');
 var ParseError = require('../core/error');
+var option = require('../api/option');
 // TODO provide types
 function unique(path, items, value, sample, resolve, traverseCallback) {
     var tmp = [], seen = [];
@@ -42,7 +43,19 @@ var arrayType = function arrayType(value, path, resolve, traverseCallback) {
             return traverseCallback(item, itemSubpath, resolve);
         }));
     }
-    var length = random.number(value.minItems, value.maxItems, 1, 5), 
+    var minItems = value.minItems;
+    var maxItems = value.maxItems;
+    if (option('maxItems')) {
+        // Don't allow user to set max items above our maximum
+        if (maxItems && maxItems > option('maxItems')) {
+            maxItems = option('maxItems');
+        }
+        // Don't allow user to set min items above our maximum
+        if (minItems && minItems > option('maxItems')) {
+            minItems = maxItems;
+        }
+    }
+    var length = random.number(minItems, maxItems, 1, 5), 
     // TODO below looks bad. Should additionalItems be copied as-is?
     sample = typeof value.additionalItems === 'object' ? value.additionalItems : {};
     for (var current = items.length; current < length; current++) {

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -4,6 +4,7 @@ var ipv4 = require('../generators/ipv4');
 var dateTime = require('../generators/dateTime');
 var coreFormat = require('../generators/coreFormat');
 var format = require('../api/format');
+var option = require('../api/option');
 var container = require('../class/Container');
 var randexp = container.get('randexp');
 function generateFormat(value) {
@@ -33,7 +34,19 @@ var stringType = function stringType(value) {
         return randexp(value.pattern);
     }
     else {
-        return thunk(value.minLength, value.maxLength);
+        var minLength = value.minLength;
+        var maxLength = value.maxLength;
+        if (option('maxLength')) {
+            // Don't allow user to set max length above our maximum
+            if (maxLength && maxLength > option('maxLength')) {
+                maxLength = option('maxLength');
+            }
+            // Don't allow user to set min length above our maximum
+            if (minLength && minLength > option('maxLength')) {
+                minLength = option('maxLength');
+            }
+        }
+        return thunk(minLength, maxLength);
     }
 };
 module.exports = stringType;

--- a/ts/class/OptionRegistry.ts
+++ b/ts/class/OptionRegistry.ts
@@ -12,6 +12,8 @@ class OptionRegistry extends Registry<Option> {
     this.data['failOnInvalidTypes'] = true;
     this.data['defaultInvalidTypeProduct'] = null;
     this.data['useDefaultValue'] = false;
+    this.data['maxItems'] = null;
+    this.data['maxLength'] = null;
   }
 }
 

--- a/ts/types/array.ts
+++ b/ts/types/array.ts
@@ -1,6 +1,7 @@
 import random = require('../core/random');
 import utils = require('../core/utils');
 import ParseError = require('../core/error');
+import option = require('../api/option');
 
 // TODO provide types
 function unique(path: SchemaPath, items, value, sample, resolve, traverseCallback: Function) {
@@ -56,7 +57,22 @@ var arrayType: FTypeGenerator = function arrayType(value: IArraySchema, path: Sc
     }));
   }
 
-  var length: number = random.number(value.minItems, value.maxItems, 1, 5),
+  var minItems = value.minItems;
+  var maxItems = value.maxItems;
+
+  if (option('maxItems')) {
+    // Don't allow user to set max items above our maximum
+    if (maxItems && maxItems > option('maxItems')) {
+      maxItems = option('maxItems');
+    }
+
+    // Don't allow user to set min items above our maximum
+    if (minItems && minItems > option('maxItems')) {
+      minItems = maxItems;
+    }
+  }
+
+  var length: number = random.number(minItems, maxItems, 1, 5),
       // TODO below looks bad. Should additionalItems be copied as-is?
       sample: Object = typeof value.additionalItems === 'object' ? value.additionalItems : {};
 

--- a/ts/types/string.ts
+++ b/ts/types/string.ts
@@ -3,6 +3,7 @@ import ipv4 = require('../generators/ipv4');
 import dateTime = require('../generators/dateTime');
 import coreFormat = require('../generators/coreFormat');
 import format = require('../api/format');
+import option = require('../api/option');
 
 import container = require('../class/Container');
 var randexp = container.get('randexp');
@@ -33,7 +34,22 @@ var stringType: FTypeGenerator = function stringType(value: IStringSchema): stri
   } else if (value.pattern) {
     return randexp(value.pattern);
   } else {
-    return thunk(value.minLength, value.maxLength);
+    var minLength = value.minLength;
+    var maxLength = value.maxLength;
+
+    if (option('maxLength')) {
+      // Don't allow user to set max length above our maximum
+      if (maxLength && maxLength > option('maxLength')) {
+        maxLength = option('maxLength');
+      }
+
+      // Don't allow user to set min length above our maximum
+      if (minLength && minLength > option('maxLength')) {
+        minLength = option('maxLength');
+      }
+    }
+
+    return thunk(minLength, maxLength);
   }
 };
 


### PR DESCRIPTION
Following on the discussion from https://github.com/json-schema-faker/json-schema-faker/issues/199, this PR adds two new options to force a limit of an array items and string length.

I've tested both of these manually, here's an example:

```js
var faker = require('json-schema-faker');

faker.option({
  maxItems: 10,
  maxLength: 32,
});

console.log(JSON.stringify(faker({
  "type": "array",
  "items": {
    "type": "string",
    "minLength": 10000,
    "maxLength": 100000,
  },
  "maxItems": 100,
  "minItems": 100,
}), null, 2));

```

```json
[
  "est doid non sit Loremculpa ipsu",
  "adlaborumconsequat dolore Lorem ",
  "eiusmod reprehenderit animut pro",
  "irureut sed aliqua exercitationv",
  "ex proidentnon ullamco magna mol",
  "nonadipisicing officiaanim quide",
  "aute nulla temporaliqua laborum ",
  "officia dolor exercitation adipi",
  "laborum sed sit adipisicinganim ",
  "labore idin ametest culpa deseru"
]
```

Unfortunately I'm not entirely sure where the tests would belong for this, can someone point me to the place where tests for this behaviour would belong?