### PR TITLE
Allow custom format for additionalProperties property names

### DIFF
--- a/spec/schema/core/types/object.json
+++ b/spec/schema/core/types/object.json
@@ -285,6 +285,32 @@
           }
         },
         "type": "object"
+      },
+      {
+        "description": "should handle additionalPropertiesFormat",
+        "schema": {
+          "type": "object",
+          "minProperties": 5,
+          "maxProperties": 5,
+          "additionalPropertiesFormat": "date-time",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "should validate additionalPropertiesFormat core formats",
+        "schema": {
+          "type": "object",
+          "minProperties": 1,
+          "maxProperties": 1,
+          "additionalPropertiesFormat": "unknown",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "throws": "Error: unknown registry key .+? in \\/"
       }
     ]
   }

--- a/ts/api/format.ts
+++ b/ts/api/format.ts
@@ -1,4 +1,7 @@
 import Registry = require('../class/Registry');
+import coreFormat = require('../generators/coreFormat');
+import dateTime = require('../generators/dateTime');
+import ipv4 = require('../generators/ipv4');
 
 type Format = Function;
 
@@ -20,7 +23,22 @@ function formatAPI(nameOrFormatMap?: string|Object, callback?: Format): any {
     if (typeof callback === 'function') {
       registry.register(nameOrFormatMap, callback);
     } else {
-      return registry.get(nameOrFormatMap);
+      switch (nameOrFormatMap) {
+        case 'date-time':
+          return () => dateTime();
+        case 'ipv4':
+          return () => ipv4();
+        case 'regex':
+          // TODO: discuss
+          return () => '.+?';
+        case 'email':
+        case 'hostname':
+        case 'ipv6':
+        case 'uri':
+          return () => coreFormat(nameOrFormatMap);
+        default:
+          return registry.get(nameOrFormatMap);
+      }
     }
   } else {
     registry.registerMany(nameOrFormatMap);

--- a/ts/index.d.ts
+++ b/ts/index.d.ts
@@ -37,6 +37,7 @@ interface IPropertySchema {
 
 interface IObjectSchema extends IGeneratorSchema {
   additionalProperties?: boolean;
+  additionalPropertiesFormat?: string;
   required?: string[];
   properties?: IPropertySchema;
   patternProperties?: IPropertySchema; // RegExp should be the index of this structure (see "5.4.4.1. Valid values" in http://json-schema.org/latest/json-schema-validation.html), but RegExp-key-based maps are unsupported in TypeScript

--- a/ts/types/object.ts
+++ b/ts/types/object.ts
@@ -3,6 +3,7 @@ import random = require('../core/random');
 import words = require('../generators/words');
 import utils = require('../core/utils');
 import ParseError = require('../core/error');
+import format = require('../api/format');
 
 var randexp = container.get('randexp');
 
@@ -67,6 +68,15 @@ var objectType: FTypeGenerator = function objectType(value: IObjectSchema, path,
         max = potentialPropertyKeys.length + patternPropertyKeys.length;
     }
 
+    var additionalPropertiesFormat;
+    if (allowsAdditional) {
+      if (typeof value.additionalPropertiesFormat === 'string') {
+        additionalPropertiesFormat = format(value.additionalPropertiesFormat);
+      } else {
+        additionalPropertiesFormat = function() { return words(1) + randexp('[a-f\\d]{4,7}'); };
+      }
+    }
+
     var keyCount = 0;
     var maxKeyCount = random.number(min, max);
 
@@ -95,7 +105,7 @@ var objectType: FTypeGenerator = function objectType(value: IObjectSchema, path,
                 keyCount += 1;
             }
         } else if (allowsAdditional) {
-            _key = words(1) + randexp('[a-f\\d]{4,7}');
+            _key = additionalPropertiesFormat(container.getAll(), value);
             props[_key] = additionalProperties;
             keyCount += 1;
         }

--- a/ts/types/string.ts
+++ b/ts/types/string.ts
@@ -1,36 +1,14 @@
 import thunk = require('../generators/thunk');
-import ipv4 = require('../generators/ipv4');
-import dateTime = require('../generators/dateTime');
-import coreFormat = require('../generators/coreFormat');
 import format = require('../api/format');
 import option = require('../api/option');
 
 import container = require('../class/Container');
 var randexp = container.get('randexp');
 
-function generateFormat(value: IStringSchema): string {
-  switch (value.format) {
-    case 'date-time':
-      return dateTime();
-    case 'ipv4':
-      return ipv4();
-    case 'regex':
-      // TODO: discuss
-      return '.+?';
-    case 'email':
-    case 'hostname':
-    case 'ipv6':
-    case 'uri':
-      return coreFormat(value.format);
-    default:
-      var callback: Function = format(value.format);
-      return callback(container.getAll(), value);
-  }
-}
-
 var stringType: FTypeGenerator = function stringType(value: IStringSchema): string {
   if (value.format) {
-    return generateFormat(value);
+    var callback: Function = format(value.format);
+    return callback(container.getAll(), value);
   } else if (value.pattern) {
     return randexp(value.pattern);
   } else {


### PR DESCRIPTION
When generating data for `additionalProperties`, the property names are random strings (`words(1) + randexp('[a-f\\d]{4,7}')`). The proposed `additionalProperties` allows to use any defined custom format to generate the property names.

For example, having this custom format (as shown in the docs):

```javascript
jsf.format('semver', function(gen, schema) {
  return gen.randexp('^\\d\\.\\d\\.\\d{1,2}$');
});
```

And the following JSON schema:

```json
{
  "type": "object",
  "properties": {
    "versions": {
      "type": "object",
      "minProperties": 4,
      "maxProperties": 8,
      "additionalPropertiesFormat": "semver",
      "additionalProperties": {
        "type": "object",
        "properties": {
          "author": {
          	"faker": "name.findName"
          },
          "changes": {
          	"faker": { "random.number": [99] }
          }
        },
        "required": [
          "author",
          "changes"
        ]
      }
    }
  },
  "required": [
    "versions"
  ]
}
```

A posible generated output is as follows:

```json
{
  "versions": {
    "1.8.1": {
      "author": "Lilian Schamberger",
      "changes": 85
    },
    "0.5.71": {
      "author": "Arnoldo Cormier",
      "changes": 41
    },
    "4.9.08": {
      "author": "Arianna Windler",
      "changes": 30
    },
    "5.1.12": {
      "author": "Gabriel Schuster",
      "changes": 69
    },
    "1.2.93": {
      "author": "Sheldon Yundt",
      "changes": 18
    },
    "0.1.51": {
      "author": "Meaghan Dach",
      "changes": 47
    }
  }
}
```
