### PR TITLE
Fix: patternProperties doesn't always generate required minProperties

### DIFF
--- a/ts/types/object.ts
+++ b/ts/types/object.ts
@@ -80,7 +80,7 @@ var objectType: FTypeGenerator = function objectType(value: IObjectSchema, path,
 
     var index, _key;
     while (keyCount < maxKeyCount && tries < maxTries && propSpace > 0) {
-        index = random.number(0, propSpace);
+        index = random.number(0, propSpace - 1);
         if (index < potentialPropertyKeys.length) {
             _key = potentialPropertyKeys.splice(index, 1);
             props[_key] = properties[_key];


### PR DESCRIPTION
Demo: http://json-schema-faker.js.org/#gist/9aadcc1ea948946fcb1ad28896692ea4

In some cases when using `patternProperties` in conjunction with `minProperties`, less than `minProperties` properties are generated. This PR fixes it.

Also, this was the cause of seeing the `spec/schema/core/types/object.json` test randomly failing:

```
Failures:

  1) object generator (core/types/object.json) should handle maxProperties
    Message:
      Expected type string but found type undefined
ValidationError: Invalid type: undefined (expected string)
Invalid schema {"c":"magna Duis deserunt ea ad"}
```