### PR TITLE
Allow generation of numbers with fractional part.

### DIFF
--- a/lib/class/OptionRegistry.js
+++ b/lib/class/OptionRegistry.js
@@ -14,6 +14,7 @@ var OptionRegistry = (function (_super) {
         var _this = _super.call(this) || this;
         _this.data['failOnInvalidTypes'] = true;
         _this.data['defaultInvalidTypeProduct'] = null;
+        _this.data['failOnInvalidFormat'] = true;
         _this.data['useDefaultValue'] = false;
         _this.data['requiredOnly'] = false;
         _this.data['maxItems'] = null;

--- a/lib/class/Registry.js
+++ b/lib/class/Registry.js
@@ -26,9 +26,6 @@ var Registry = (function () {
      */
     Registry.prototype.get = function (name) {
         var format = this.data[name];
-        if (typeof format === 'undefined') {
-            throw new Error('unknown registry key ' + JSON.stringify(name));
-        }
         return format;
     };
     /**

--- a/lib/core/random.js
+++ b/lib/core/random.js
@@ -37,8 +37,8 @@ var MIN_NUMBER = -100, MAX_NUMBER = 100;
  * Using Math.round() will give you a non-uniform distribution!
  * @see http://stackoverflow.com/a/1527820/769384
  */
-function getRandomInt(min, max) {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+function getRandom(min, max) {
+    return Math.random() * (max - min) + min;
 }
 /**
  * Generates random number according to parameters passed
@@ -59,7 +59,7 @@ function number(min, max, defMin, defMax, hasPrecision) {
     if (max < min) {
         max += min;
     }
-    var result = getRandomInt(min, max);
+    var result = getRandom(min, max);
     if (!hasPrecision) {
         return parseInt(result + '', 10);
     }

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -7,7 +7,7 @@ var format = require("../api/format");
 var option = require("../api/option");
 var container = require("../class/Container");
 var randexp = container.get('randexp');
-function generateFormat(value) {
+function generateFormat(value, invalid) {
     switch (value.format) {
         case 'date-time':
             return dateTime();
@@ -23,6 +23,14 @@ function generateFormat(value) {
             return coreFormat(value.format);
         default:
             var callback = format(value.format);
+            if (typeof callback === 'undefined') {
+                if (option('failOnInvalidFormat')) {
+                    throw new Error('unknown registry key ' + JSON.stringify(value.format));
+                }
+                else {
+                    return invalid();
+                }
+            }
             return callback(container.getAll(), value);
     }
 }
@@ -41,7 +49,7 @@ var stringType = function stringType(value) {
         }
     }
     if (value.format) {
-        output = generateFormat(value);
+        output = generateFormat(value, function () { return thunk(minLength, maxLength); });
     }
     else if (value.pattern) {
         output = randexp(value.pattern);

--- a/spec/unit/generators/number.spec.js
+++ b/spec/unit/generators/number.spec.js
@@ -1,0 +1,8 @@
+var numberType = require('../../../lib/types/number');
+
+describe("Number Generator", function() {
+  it("should return number with a fractional part", function() {
+    var n = numberType({});
+    expect(n).not.toEqual(Math.floor(n));
+  });
+});

--- a/ts/class/OptionRegistry.ts
+++ b/ts/class/OptionRegistry.ts
@@ -11,6 +11,7 @@ class OptionRegistry extends Registry<Option> {
     super();
     this.data['failOnInvalidTypes'] = true;
     this.data['defaultInvalidTypeProduct'] = null;
+    this.data['failOnInvalidFormat'] = true;
     this.data['useDefaultValue'] = false;
     this.data['requiredOnly'] = false;
     this.data['maxItems'] = null;

--- a/ts/class/Registry.ts
+++ b/ts/class/Registry.ts
@@ -37,9 +37,6 @@ class Registry<T> {
    */
   public get(name: string): T {
     var format: T = this.data[name];
-    if (typeof format === 'undefined') {
-      throw new Error('unknown registry key ' + JSON.stringify(name));
-    }
     return format;
   }
 

--- a/ts/core/random.ts
+++ b/ts/core/random.ts
@@ -47,8 +47,8 @@ var MIN_NUMBER = -100,
  * Using Math.round() will give you a non-uniform distribution!
  * @see http://stackoverflow.com/a/1527820/769384
  */
-function getRandomInt(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+function getRandom(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
 }
 
 /**
@@ -72,7 +72,7 @@ function number(min?: number, max?: number, defMin?: number, defMax?: number, ha
     max += min;
   }
 
-  var result: number = getRandomInt(min, max);
+  var result: number = getRandom(min, max);
 
   if (!hasPrecision) {
     return parseInt(result + '', 10);

--- a/ts/types/string.ts
+++ b/ts/types/string.ts
@@ -8,7 +8,7 @@ import option = require('../api/option');
 import container = require('../class/Container');
 var randexp = container.get('randexp');
 
-function generateFormat(value: IStringSchema): string {
+function generateFormat(value: IStringSchema, invalid: () => string): string {
   switch (value.format) {
     case 'date-time':
       return dateTime();
@@ -24,6 +24,13 @@ function generateFormat(value: IStringSchema): string {
       return coreFormat(value.format);
     default:
       var callback: Function = format(value.format);
+      if (typeof callback === 'undefined') {
+        if (option('failOnInvalidFormat')) {
+          throw new Error('unknown registry key ' + JSON.stringify(value.format));
+        } else {
+          return invalid();
+        }
+      }
       return callback(container.getAll(), value);
   }
 }
@@ -47,7 +54,7 @@ var stringType: FTypeGenerator = function stringType(value: IStringSchema): stri
   }
 
   if (value.format) {
-    output = generateFormat(value);
+    output = generateFormat(value, () => thunk(minLength, maxLength) );
   } else if (value.pattern) {
     output = randexp(value.pattern);
   } else {


### PR DESCRIPTION
When requesting numbers with format double or float, json-schema-faker currently only generates integer values. This PR allows the output to generate fractional numbers, (unless format:integer is specified). 