### PR TITLE
Allow for a fallback if format is not recognized.

### DIFF
--- a/lib/class/OptionRegistry.js
+++ b/lib/class/OptionRegistry.js
@@ -14,6 +14,7 @@ var OptionRegistry = (function (_super) {
         var _this = _super.call(this) || this;
         _this.data['failOnInvalidTypes'] = true;
         _this.data['defaultInvalidTypeProduct'] = null;
+        _this.data['failOnInvalidFormat'] = true;
         _this.data['useDefaultValue'] = false;
         _this.data['requiredOnly'] = false;
         _this.data['maxItems'] = null;

--- a/lib/class/Registry.js
+++ b/lib/class/Registry.js
@@ -26,9 +26,6 @@ var Registry = (function () {
      */
     Registry.prototype.get = function (name) {
         var format = this.data[name];
-        if (typeof format === 'undefined') {
-            throw new Error('unknown registry key ' + JSON.stringify(name));
-        }
         return format;
     };
     /**

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -7,7 +7,7 @@ var format = require("../api/format");
 var option = require("../api/option");
 var container = require("../class/Container");
 var randexp = container.get('randexp');
-function generateFormat(value) {
+function generateFormat(value, invalid) {
     switch (value.format) {
         case 'date-time':
             return dateTime();
@@ -23,6 +23,14 @@ function generateFormat(value) {
             return coreFormat(value.format);
         default:
             var callback = format(value.format);
+            if (typeof callback === 'undefined') {
+                if (option('failOnInvalidFormat')) {
+                    throw new Error('unknown registry key ' + JSON.stringify(value.format));
+                }
+                else {
+                    return invalid();
+                }
+            }
             return callback(container.getAll(), value);
     }
 }
@@ -41,7 +49,7 @@ var stringType = function stringType(value) {
         }
     }
     if (value.format) {
-        output = generateFormat(value);
+        output = generateFormat(value, function () { return thunk(minLength, maxLength); });
     }
     else if (value.pattern) {
         output = randexp(value.pattern);

--- a/ts/class/OptionRegistry.ts
+++ b/ts/class/OptionRegistry.ts
@@ -11,6 +11,7 @@ class OptionRegistry extends Registry<Option> {
     super();
     this.data['failOnInvalidTypes'] = true;
     this.data['defaultInvalidTypeProduct'] = null;
+    this.data['failOnInvalidFormat'] = true;
     this.data['useDefaultValue'] = false;
     this.data['requiredOnly'] = false;
     this.data['maxItems'] = null;

--- a/ts/class/Registry.ts
+++ b/ts/class/Registry.ts
@@ -37,9 +37,6 @@ class Registry<T> {
    */
   public get(name: string): T {
     var format: T = this.data[name];
-    if (typeof format === 'undefined') {
-      throw new Error('unknown registry key ' + JSON.stringify(name));
-    }
     return format;
   }
 

--- a/ts/types/string.ts
+++ b/ts/types/string.ts
@@ -8,7 +8,7 @@ import option = require('../api/option');
 import container = require('../class/Container');
 var randexp = container.get('randexp');
 
-function generateFormat(value: IStringSchema): string {
+function generateFormat(value: IStringSchema, invalid: () => string): string {
   switch (value.format) {
     case 'date-time':
       return dateTime();
@@ -24,6 +24,13 @@ function generateFormat(value: IStringSchema): string {
       return coreFormat(value.format);
     default:
       var callback: Function = format(value.format);
+      if (typeof callback === 'undefined') {
+        if (option('failOnInvalidFormat')) {
+          throw new Error('unknown registry key ' + JSON.stringify(value.format));
+        } else {
+          return invalid();
+        }
+      }
       return callback(container.getAll(), value);
   }
 }
@@ -47,7 +54,7 @@ var stringType: FTypeGenerator = function stringType(value: IStringSchema): stri
   }
 
   if (value.format) {
-    output = generateFormat(value);
+    output = generateFormat(value, () => thunk(minLength, maxLength) );
   } else if (value.pattern) {
     output = randexp(value.pattern);
   } else {


### PR DESCRIPTION
Allow an option to ignore schema format if it's not supported. Act as if no format was provided.