### PR TITLE
Allow generation of numbers with fractional part.

### DIFF
--- a/lib/core/random.js
+++ b/lib/core/random.js
@@ -1,0 +1,72 @@
+/// <reference path="../index.d.ts" />
+"use strict";
+/**
+ * Returns random element of a collection
+ *
+ * @param collection
+ * @returns {T}
+ */
+function pick(collection) {
+    return collection[Math.floor(Math.random() * collection.length)];
+}
+/**
+ * Returns shuffled collection of elements
+ *
+ * @param collection
+ * @returns {T[]}
+ */
+function shuffle(collection) {
+    var tmp, key, copy = collection.slice(), length = collection.length;
+    for (; length > 0;) {
+        key = Math.floor(Math.random() * length);
+        // swap
+        tmp = copy[--length];
+        copy[length] = copy[key];
+        copy[key] = tmp;
+    }
+    return copy;
+}
+/**
+ * These values determine default range for random.number function
+ *
+ * @type {number}
+ */
+var MIN_NUMBER = -100, MAX_NUMBER = 100;
+/**
+ * Returns a random integer between min (inclusive) and max (inclusive)
+ * Using Math.round() will give you a non-uniform distribution!
+ * @see http://stackoverflow.com/a/1527820/769384
+ */
+function getRandom(min, max) {
+    return Math.random() * (max - min) + min;
+}
+/**
+ * Generates random number according to parameters passed
+ *
+ * @param min
+ * @param max
+ * @param defMin
+ * @param defMax
+ * @param hasPrecision
+ * @returns {number}
+ */
+function number(min, max, defMin, defMax, hasPrecision) {
+    if (hasPrecision === void 0) { hasPrecision = false; }
+    defMin = typeof defMin === 'undefined' ? MIN_NUMBER : defMin;
+    defMax = typeof defMax === 'undefined' ? MAX_NUMBER : defMax;
+    min = typeof min === 'undefined' ? defMin : min;
+    max = typeof max === 'undefined' ? defMax : max;
+    if (max < min) {
+        max += min;
+    }
+    var result = getRandom(min, max);
+    if (!hasPrecision) {
+        return parseInt(result + '', 10);
+    }
+    return result;
+}
+module.exports = {
+    pick: pick,
+    shuffle: shuffle,
+    number: number
+};

--- a/spec/unit/generators/number.spec.js
+++ b/spec/unit/generators/number.spec.js
@@ -1,4 +1,4 @@
-var numberType = require('../../../lib/types/number');
+var numberType = require('../../../ts/types/number').default;
 
 describe("Number Generator", function() {
   it("should return number with a fractional part", function() {

--- a/spec/unit/generators/number.spec.js
+++ b/spec/unit/generators/number.spec.js
@@ -1,0 +1,8 @@
+var numberType = require('../../../lib/types/number');
+
+describe("Number Generator", function() {
+  it("should return number with a fractional part", function() {
+    var n = numberType({});
+    expect(n).not.toEqual(Math.floor(n));
+  });
+});

--- a/ts/core/random.ts
+++ b/ts/core/random.ts
@@ -47,8 +47,8 @@ var MIN_NUMBER = -100,
  * Using Math.round() will give you a non-uniform distribution!
  * @see http://stackoverflow.com/a/1527820/769384
  */
-function getRandomInt(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+function getRandom(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
 }
 
 /**
@@ -72,7 +72,7 @@ function number(min?: number, max?: number, defMin?: number, defMax?: number, ha
     max += min;
   }
 
-  var result: number = getRandomInt(min, max);
+  var result: number = getRandom(min, max);
 
   if (!hasPrecision) {
     return parseInt(result + '', 10);


### PR DESCRIPTION
When requesting numbers with format double or float, json-schema-faker currently only generates integer values. This PR allows the output to generate fractional numbers, (unless format:integer is specified).