### PR TITLE
Allow for a fallback if format is not recognized.

### DIFF
--- a/lib/class/OptionRegistry.js
+++ b/lib/class/OptionRegistry.js
@@ -1,0 +1,29 @@
+"use strict";
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var Registry = require("./Registry");
+/**
+ * This class defines a registry for custom formats used within JSF.
+ */
+var OptionRegistry = (function (_super) {
+    __extends(OptionRegistry, _super);
+    function OptionRegistry() {
+        var _this = _super.call(this) || this;
+        _this.data['failOnInvalidTypes'] = true;
+        _this.data['defaultInvalidTypeProduct'] = null;
+        _this.data['failOnInvalidFormat'] = true;
+        _this.data['useDefaultValue'] = false;
+        _this.data['requiredOnly'] = false;
+        _this.data['maxItems'] = null;
+        _this.data['maxLength'] = null;
+        _this.data['defaultMinItems'] = 0;
+        _this.data['defaultRandExpMax'] = 10;
+        _this.data['alwaysFakeOptionals'] = false;
+        return _this;
+    }
+    return OptionRegistry;
+}(Registry));
+module.exports = OptionRegistry;

--- a/lib/class/Registry.js
+++ b/lib/class/Registry.js
@@ -1,0 +1,39 @@
+"use strict";
+/**
+ * This class defines a registry for custom formats used within JSF.
+ */
+var Registry = (function () {
+    function Registry() {
+        // empty by default
+        this.data = {};
+    }
+    /**
+     * Registers custom format
+     */
+    Registry.prototype.register = function (name, callback) {
+        this.data[name] = callback;
+    };
+    /**
+     * Register many formats at one shot
+     */
+    Registry.prototype.registerMany = function (formats) {
+        for (var name in formats) {
+            this.data[name] = formats[name];
+        }
+    };
+    /**
+     * Returns element by registry key
+     */
+    Registry.prototype.get = function (name) {
+        var format = this.data[name];
+        return format;
+    };
+    /**
+     * Returns the whole registry content
+     */
+    Registry.prototype.list = function () {
+        return this.data;
+    };
+    return Registry;
+}());
+module.exports = Registry;

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -1,0 +1,68 @@
+"use strict";
+var thunk = require("../generators/thunk");
+var ipv4 = require("../generators/ipv4");
+var dateTime = require("../generators/dateTime");
+var coreFormat = require("../generators/coreFormat");
+var format = require("../api/format");
+var option = require("../api/option");
+var container = require("../class/Container");
+var randexp = container.get('randexp');
+function generateFormat(value, invalid) {
+    switch (value.format) {
+        case 'date-time':
+            return dateTime();
+        case 'ipv4':
+            return ipv4();
+        case 'regex':
+            // TODO: discuss
+            return '.+?';
+        case 'email':
+        case 'hostname':
+        case 'ipv6':
+        case 'uri':
+            return coreFormat(value.format);
+        default:
+            var callback = format(value.format);
+            if (typeof callback === 'undefined') {
+                if (option('failOnInvalidFormat')) {
+                    throw new Error('unknown registry key ' + JSON.stringify(value.format));
+                }
+                else {
+                    return invalid();
+                }
+            }
+            return callback(container.getAll(), value);
+    }
+}
+var stringType = function stringType(value) {
+    var output;
+    var minLength = value.minLength;
+    var maxLength = value.maxLength;
+    if (option('maxLength')) {
+        // Don't allow user to set max length above our maximum
+        if (maxLength && maxLength > option('maxLength')) {
+            maxLength = option('maxLength');
+        }
+        // Don't allow user to set min length above our maximum
+        if (minLength && minLength > option('maxLength')) {
+            minLength = option('maxLength');
+        }
+    }
+    if (value.format) {
+        output = generateFormat(value, function () { return thunk(minLength, maxLength); });
+    }
+    else if (value.pattern) {
+        output = randexp(value.pattern);
+    }
+    else {
+        output = thunk(minLength, maxLength);
+    }
+    while (output.length < minLength) {
+        output += Math.random() > 0.7 ? thunk() : randexp('.+');
+    }
+    if (output.length > maxLength) {
+        output = output.substr(0, maxLength);
+    }
+    return output;
+};
+module.exports = stringType;

--- a/ts/class/OptionRegistry.ts
+++ b/ts/class/OptionRegistry.ts
@@ -11,6 +11,7 @@ class OptionRegistry extends Registry<Option> {
     super();
     this.data['failOnInvalidTypes'] = true;
     this.data['defaultInvalidTypeProduct'] = null;
+    this.data['failOnInvalidFormat'] = true;
     this.data['useDefaultValue'] = false;
     this.data['requiredOnly'] = false;
     this.data['maxItems'] = null;

--- a/ts/class/Registry.ts
+++ b/ts/class/Registry.ts
@@ -37,9 +37,6 @@ class Registry<T> {
    */
   public get(name: string): T {
     var format: T = this.data[name];
-    if (typeof format === 'undefined') {
-      throw new Error('unknown registry key ' + JSON.stringify(name));
-    }
     return format;
   }
 


### PR DESCRIPTION
Allow an option to ignore schema format if it's not supported. Act as if no format was provided.