### PR TITLE
Include dist on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,5 +18,4 @@ tslint.json
 /node_modules
 /ts
 /docs
-/dist
 /logo

--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,4 @@ tslint.json
 /coverage
 /generated
 /node_modules
-/ts
-/docs
 /logo


### PR DESCRIPTION
In the README, it is recommended to use bundles in the `/dist` folder when using JSF in a browser. However, when using npm to manage browser dependencies, JSF excludes its `/dist` folder from the registry. This PR removes `/dist` from `.npmignore` and also cleans up a few duplicate entries.

If this PR is acceptable, what would it take to get it into the next RC?