### PR TITLE
Option to override random generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ You may define following options for `jsf` that alter its behavior:
 - `failOnInvalidFormat`: boolean - don't throw exception when invalid format passed
 - `maxItems`: number - Configure a maximum amount of items to generate in an array. This will override the maximum items found inside a JSON Schema.
 - `maxLength`: number - Configure a maximum length to allow generating strings for. This will override the maximum length found inside a JSON Schema.
+- `random`: Function - a replacement for `Math.random` to support pseudorandom number generation.
 
 Set options just as below:
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "rollup": "^0.41.6",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "seedrandom": "^2.4.3",
     "semver": "^5.3.0",
     "tarima": "^3.2.1",
     "ts-node": "^3.0.4",

--- a/spec/schema/core/option/random.js
+++ b/spec/schema/core/option/random.js
@@ -1,0 +1,9 @@
+const seedrandom = require('seedrandom');
+
+module.exports = {
+    register: function(jsf) {
+        return jsf.option({
+            random: seedrandom('some seed')
+        });
+    }
+};

--- a/spec/schema/core/option/random.json
+++ b/spec/schema/core/option/random.json
@@ -1,0 +1,35 @@
+[
+  {
+    "description": "random option",
+    "tests": [
+      {
+        "description": "should allow pseudorandom value generation",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            },
+            "b": {
+              "type": "string"
+            },
+            "c": {
+              "pattern": "^[a-z]{2}[0-9]{3}$"
+            }
+          },
+          "required": ["a", "b", "c"]
+        },
+        "valid": true,
+        "equal": {
+          "a": 38,
+          "b": "dolore et qui",
+          "c": "hv837"
+        },
+        "repeat": 1,
+        "require": "core/option/random"
+      }
+    ]
+  }
+]

--- a/ts/class/OptionRegistry.ts
+++ b/ts/class/OptionRegistry.ts
@@ -1,6 +1,6 @@
 import Registry from './Registry';
 
-type Option = boolean|number;
+type Option = boolean|number|Function;
 
 /**
  * This class defines a registry for custom settings used within JSF.
@@ -19,6 +19,7 @@ class OptionRegistry extends Registry<Option> {
     this.data['defaultMinItems'] = 0;
     this.data['defaultRandExpMax'] = 10;
     this.data['alwaysFakeOptionals'] = false;
+    this.data['random'] = Math.random;
   }
 }
 

--- a/ts/core/random.ts
+++ b/ts/core/random.ts
@@ -1,5 +1,7 @@
 /// <reference path="../index.d.ts" />
 
+import optionAPI from '../api/option';
+
 /**
  * Returns random element of a collection
  *
@@ -7,7 +9,7 @@
  * @returns {T}
  */
 function pick<T>(collection: T[]): T {
-  return collection[Math.floor(Math.random() * collection.length)];
+  return collection[Math.floor(optionAPI('random')() * collection.length)];
 }
 
 /**
@@ -23,7 +25,7 @@ function shuffle<T>(collection: T[]): T[] {
     length: number = collection.length;
 
   for (; length > 0;) {
-    key = Math.floor(Math.random() * length);
+    key = Math.floor(optionAPI('random')() * length);
     // swap
     tmp = copy[--length];
     copy[length] = copy[key];
@@ -48,7 +50,7 @@ var MIN_NUMBER = -100,
  * @see http://stackoverflow.com/a/1527820/769384
  */
 function getRandom(min: number, max: number): number {
-  return Math.random() * (max - min) + min;
+  return optionAPI('random')() * (max - min) + min;
 }
 
 /**

--- a/ts/core/utils.ts
+++ b/ts/core/utils.ts
@@ -5,6 +5,10 @@ const RandExp = require('randexp');
 // set maximum default, see #193
 RandExp.prototype.max = 10;
 
+// same implementation as the original except using our random
+RandExp.prototype.randInt = (a, b) =>
+  a + Math.floor(optionAPI('random')() * (1 + b - a));
+
 function _randexp(value: string) {
   var re = new RandExp(value);
 

--- a/ts/generators/boolean.ts
+++ b/ts/generators/boolean.ts
@@ -1,10 +1,12 @@
+import optionAPI from '../api/option';
+
 /**
  * Generates randomized boolean value.
  *
  * @returns {boolean}
  */
 function booleanGenerator(): boolean {
-  return Math.random() > 0.5;
+  return optionAPI('random')() > 0.5;
 }
 
 export default booleanGenerator;

--- a/ts/types/string.ts
+++ b/ts/types/string.ts
@@ -66,7 +66,7 @@ var stringType: FTypeGenerator = function stringType(value: IStringSchema): stri
   }
 
   while (output.length < minLength) {
-    output += Math.random() > 0.7 ? thunk() : utils.randexp('.+');
+    output += optionAPI('random')() > 0.7 ? thunk() : utils.randexp('.+');
   }
 
   if (output.length > maxLength) {


### PR DESCRIPTION
fixes #111 

This allows deterministic results by adding a `random` option that takes a function to replace `Math.random`, which continues being the default, so no breaking changes are expected.

`Randexp.prototype.randInt` is overridden to use that new `random` option (see https://github.com/fent/randexp.js/blob/7ca2578ad28ff9fe38cc8c7ddfd6716881eea900/README.md#custom-prng).

A typical full setup could look like this:

```js
const jsf = require("json-schema-faker");
const faker = require("faker");
const seedrandom = require("seedrandom");

const seed = 123;

jsf.option({
  random: seedrandom(String(seed))
});

jsf.extend("faker", () => {
  faker.seed(seed);
  return faker;
});

```