### PR TITLE
Fix random integers

### DIFF
--- a/ts/core/random.ts
+++ b/ts/core/random.ts
@@ -75,7 +75,7 @@ function number(min?: number, max?: number, defMin?: number, defMax?: number, ha
   var result: number = getRandom(min, max);
 
   if (!hasPrecision) {
-    return parseInt(result + '', 10);
+    return Math.round(result);
   }
 
   return result;


### PR DESCRIPTION
There was a bug in the random number generator. In `types/array.ts`, there is a call to `random.number`. 

`random.number(1, 2, 1, 5)` would always return `1`. It should have a 50% chance of returning both `1` and `2`.