### PR TITLE
If alwaysFakeOptionals option is true, then generate maximum number of values for array

### DIFF
--- a/ts/types/array.ts
+++ b/ts/types/array.ts
@@ -79,9 +79,10 @@ var arrayType: FTypeGenerator = function arrayType(value: IArraySchema, path: Sc
     }
   }
 
-  var length: number = random.number(minItems, maxItems, 1, 5),
-      // TODO below looks bad. Should additionalItems be copied as-is?
-      sample: Object = typeof value.additionalItems === 'object' ? value.additionalItems : {};
+  var length: number = (maxItems != null && optionAPI('alwaysFakeOptionals')) ?
+    maxItems : random.number(minItems, maxItems, 1, 5),
+    // TODO below looks bad. Should additionalItems be copied as-is?
+    sample: Object = typeof value.additionalItems === 'object' ? value.additionalItems : {};
 
   for (var current: number = items.length; current < length; current++) {
     var itemSubpath: SchemaPath = path.concat(['items', current + '']);


### PR DESCRIPTION
There is an [`alwaysFakeOptionals` setting](https://github.com/json-schema-faker/json-schema-faker/commit/e0f08e98f2803ad3e13ac8817e15461ea26f83a2). If this is true, then all the optional properties are generated for an object.

This PR adds `alwaysFakeOptionals` support to arrays. If an array has a `maxItems` value, then it will always generate the maximum number of entries for the array.