### PR TITLE
Fix order so that default values are always used, even for enums

### DIFF
--- a/ts/core/traverse.ts
+++ b/ts/core/traverse.ts
@@ -13,6 +13,10 @@ function traverse(schema: JsonSchema, path: SchemaPath, resolve: Function) {
     return;
   }
 
+  if (optionAPI('useDefaultValue') && 'default' in schema) {
+    return schema.default;
+  }
+
   if (Array.isArray(schema.enum)) {
     return random.pick(schema.enum);
   }
@@ -24,10 +28,6 @@ function traverse(schema: JsonSchema, path: SchemaPath, resolve: Function) {
 
   if (typeof schema.generate === 'function') {
     return utils.typecast(schema.generate(), schema);
-  }
-
-  if (optionAPI('useDefaultValue') && 'default' in schema) {
-    return schema.default;
   }
 
   // TODO remove the ugly overcome


### PR DESCRIPTION
I had an enum where the default was being skipped