### PR TITLE
String slug format faker

### DIFF
--- a/src/generators/coreFormat.js
+++ b/src/generators/coreFormat.js
@@ -13,6 +13,7 @@ const regexps = {
   hostname: '[a-zA-Z]{1,33}\\.[a-z]{2,4}',
   ipv6: '[a-f\\d]{4}(:[a-f\\d]{4}){7}',
   uri: URI_PATTERN,
+  slug: '[a-zA-Z\\d_-]+',
 
   // types from draft-0[67] (?)
   'uri-reference': `${URI_PATTERN}${PARAM_PATTERN}`,

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -39,6 +39,7 @@ function generateFormat(value, invalid) {
     case 'idn-email':
     case 'idn-hostname':
     case 'json-pointer':
+    case 'slug':
     case 'uri-template':
     case 'uuid':
       return coreFormat(value.format);


### PR DESCRIPTION
A 'slug' is a standard web publishing term for the part of the URL that references a particular post or page.  It is usually generated from the title, but is URL safe, so the pattern is `[A-Za-z0-9_-]`.

We add support for generating slugs within a schema.