### PR TITLE
Update clone to be "stackless"

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -193,18 +193,7 @@ function merge(a, b) {
 }
 
 function clone(obj) {
-  if (!obj || typeof obj !== 'object') {
-    return obj;
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.map(x => clone(x));
-  }
-
-  return Object.keys(obj).reduce((prev, cur) => {
-    prev[cur] = clone(obj[cur]);
-    return prev;
-  }, {});
+  return JSON.parse(JSON.stringify(obj));
 }
 
 function short(schema) {


### PR DESCRIPTION
Hey! Thank you for the fantastic package. It has helped me catch a lot of errors in my tests by using fuzzing test. 
However, sometimes my tests fail because of stack errors. I've tried increasing the stack but that just causes memory to run out. I think this is due to objects with repetitive references. This is simple, less stack intensive solution.