### PR TITLE
Resolve issue with required field in oneOf

### DIFF
--- a/src/core/run.js
+++ b/src/core/run.js
@@ -169,7 +169,7 @@ function run(refs, schema, container) {
             if (sub.oneOf) {
               mix.forEach(omit => {
                 if (omit !== fixed && omit.required) {
-                  omit.required.filter(required => !fixed.required.includes(required)).forEach(function (key) {
+                  omit.required.filter(required => !(fixed.required || []).includes(required)).forEach(function (key) {
                     delete copy.properties[key];
                   });
                 }


### PR DESCRIPTION
Having a schema that has a oneOf definition as such:

```
{
  "oneOf": [
    { required: ["foo"], /*...*/ },
    { /*...*/ },
  ]
}
```

causes the changed line to fail with error message `calling includes on undefined`. This does not always happen, as it appears that the "oneOf" field is being picked by random.

This patch simply uses a default empty array if `fixed.required` is undefined, resolving this issue.