### PR TITLE
Resolve nested definitions

### DIFF
--- a/src/lib/core/run.js
+++ b/src/lib/core/run.js
@@ -150,7 +150,7 @@ function run(refs, schema, container) {
         }
 
         if (sub.$ref.indexOf('#/definitions/') === 0) {
-          ref = schema.definitions[sub.$ref.split('#/definitions/')[1]] || null;
+          ref = sub.$ref.split("/").slice(1).reduce((obj, key) => obj ? obj[key] : null, schema);
         }
 
         if (typeof ref !== 'undefined') {


### PR DESCRIPTION
Perhaps you'd like to have nested definitions in your JSON schema, for example it might be suitable to have them arranged hierarchically by category in some case. With the proposed change nested definitions can be resolved.

I don't have the time to get to know the project enough to write any unit tests, but given the small size of the change, and that it _works on my machine™_, I thought it might be worthwhile to submit the PR anyway.

Small example schema:
```
{
	$id: "example",
	$schema: "http://json-schema.org/draft-07/schema#",
	type: "object",
	additionalProperties: false,
	definitions: {
		someDefinitionsCategory: {
			someDefinition: {
				type: "number"
			},
		},
	},
	properties: {
		x: { $ref: "#/definitions/someDefinitionsCategory/someDefinition" },
	},
	required: ["x"],
}
```

Trying to generate from the small example schema currently gives:
`Error: Reference not found: #/definitions/someDefinitionsCategory/someDefinition`