### PR TITLE
Use min max length from options even when not defined in the schema

### DIFF
--- a/src/lib/core/utils.js
+++ b/src/lib/core/utils.js
@@ -82,25 +82,15 @@ function typecast(type, schema, callback) {
       break;
 
     case 'string': {
+      params.minLength = optionAPI('minLength') || 0;
+      params.maxLength = optionAPI('maxLength') || Number.MAX_SAFE_INTEGER;
+
       if (typeof schema.minLength !== 'undefined') {
-        params.minLength = schema.minLength;
+        params.minLength = Math.max(params.minLength, schema.minLength);
       }
 
       if (typeof schema.maxLength !== 'undefined') {
-        params.maxLength = schema.maxLength;
-      }
-
-      const _maxLength = optionAPI('maxLength');
-      const _minLength = optionAPI('minLength');
-
-      // Don't allow user to set max length above our maximum
-      if (_maxLength && params.maxLength > _maxLength) {
-        params.maxLength = _maxLength;
-      }
-
-      // Don't allow user to set min length above our maximum
-      if (_minLength && params.minLength < _minLength) {
-        params.minLength = _minLength;
+        params.maxLength = Math.min(params.maxLength, schema.maxLength);
       }
 
       break;

--- a/tests/unit/core/utils.spec.js
+++ b/tests/unit/core/utils.spec.js
@@ -76,28 +76,45 @@ describe('Utils', () => {
       });
     });
 
-    it('should normalize constraints with global options', () => {
+    it('should use global options when not defined in the schema', () => {
       optionAPI({
+        minLength: 3,
         maxLength: 4,
       });
 
       utils.typecast(null, {
         type: 'string',
+      }, opts => {
+        expect(opts).to.eql({ minLength: 3, maxLength: 4 });
+      });
+    });
+
+    it('should normalize constraints with global options', () => {
+      optionAPI({
+        minLength: 3,
+        maxLength: 4,
+      });
+
+      utils.typecast(null, {
+        type: 'string',
+        minLength: 2,
         maxLength: 10,
       }, opts => {
-        expect(opts).to.eql({ maxLength: 4 });
+        expect(opts).to.eql({ minLength: 3, maxLength: 4 });
       });
     });
 
     it('should accept custom types for typecasting', () => {
       optionAPI({
-        maxLength: 5,
+        minLength: 2,
+        maxLength: 10,
       });
 
       utils.typecast('string', {
-        maxLength: 10,
+        minLength: 5,
+        maxLength: 8,
       }, opts => {
-        expect(opts).to.eql({ maxLength: 5 });
+        expect(opts).to.eql({ minLength:5, maxLength: 8 });
       });
     });
   });


### PR DESCRIPTION
This PR is a follow up to the issue #547.

It fixes the behavior of `minLength` and `maxlength` when they are provided from the options. Those were not used when no equivalent parameters were defined in the schema. 

Now if they are defined in the options, this PR makes the generator take them into account even when the schema doesn't define them.