### PR TITLE
Remove only optional empty objects

### DIFF
--- a/src/lib/core/run.js
+++ b/src/lib/core/run.js
@@ -5,10 +5,6 @@ import traverse from './traverse';
 import random from './random';
 import utils from './utils';
 
-function isEmpty(value) {
-  return Object.prototype.toString.call(value) === '[object Object]' && !Object.keys(value).length;
-}
-
 function pick(data) {
   return Array.isArray(data)
     ? random.pick(data)
@@ -31,36 +27,6 @@ function cycle(data, reverse) {
   }
 
   return value;
-}
-
-function clean(obj, isArray) {
-  if (!obj || typeof obj !== 'object') {
-    return obj;
-  }
-
-  if (Array.isArray(obj)) {
-    return obj
-      .map(value => clean(value, true))
-      .filter(value => typeof value !== 'undefined');
-  }
-
-  Object.keys(obj).forEach(k => {
-    if (!isEmpty(obj[k])) {
-      const value = clean(obj[k]);
-
-      if (!isEmpty(value)) {
-        obj[k] = value;
-      }
-    } else {
-      delete obj[k];
-    }
-  });
-
-  if (!Object.keys(obj).length && isArray) {
-    return undefined;
-  }
-
-  return obj;
 }
 
 function resolve(obj, data, values, property) {
@@ -137,7 +103,7 @@ function run(refs, schema, container) {
       }
 
       if (typeof sub.$ref === 'string') {
-        const maxDepth = random.number(Math.min(refDepthMin, refDepthMax), Math.max(refDepthMin, refDepthMax)) - 1;
+        const maxDepth = Math.max(refDepthMin, refDepthMax) - 1;
 
         // increasing depth only for repeated refs seems to be fixing #258
         if (sub.$ref === '#' || (lastRef === sub.$ref && ++depth > maxDepth)) {
@@ -242,10 +208,10 @@ function run(refs, schema, container) {
     });
 
     if (optionAPI('resolveJsonPath')) {
-      return resolve(clean(result));
+      return resolve(result);
     }
 
-    return clean(result);
+    return result;
   } catch (e) {
     if (e.path) {
       throw new Error(`${e.message} in /${e.path.join('/')}`);

--- a/src/lib/core/traverse.js
+++ b/src/lib/core/traverse.js
@@ -44,13 +44,15 @@ function traverse(schema, path, resolve, rootSchema) {
 
     // build new object value from not-schema!
     if (schema.type && schema.type === 'object') {
-      return traverse(schema, path.concat(['not']), resolve, rootSchema);
+      const traverseResult = traverse(schema, path.concat(['not']), resolve, rootSchema);
+      return utils.clean(traverseResult, schema.required || [], false);
     }
   }
 
   // thunks can return sub-schemas
   if (typeof schema.thunk === 'function') {
-    return traverse(schema.thunk(rootSchema), path, resolve);
+    const traverseResult = traverse(schema.thunk(rootSchema), path, resolve);
+    return utils.clean(traverseResult, schema.required || [], false);
   }
 
   if (typeof schema.generate === 'function') {
@@ -111,7 +113,7 @@ function traverse(schema, path, resolve, rootSchema) {
 
   Object.keys(schema).forEach(prop => {
     if (typeof schema[prop] === 'object' && prop !== 'definitions') {
-      copy[prop] = traverse(schema[prop], path.concat([prop]), resolve, copy);
+      copy[prop] = utils.clean(traverse(schema[prop], path.concat([prop]), resolve, copy), schema[prop].required || [], false);
     } else {
       copy[prop] = schema[prop];
     }

--- a/tests/schema/core/extend/mockjs-extend.js
+++ b/tests/schema/core/extend/mockjs-extend.js
@@ -1,11 +1,11 @@
 module.exports = {
   extend() {
-    var Mock = require('mockjs');
+    let Mock = require('mockjs');
 
     return {
-      mock: function (xx) {
+      mock(xx) {
         return Mock.mock(xx);
-      }
+      },
     };
   },
   register(jsf) {

--- a/tests/schema/core/issues/issue-569.json
+++ b/tests/schema/core/issues/issue-569.json
@@ -1,0 +1,61 @@
+{
+    "description": "keep empty required objects",
+    "tests": [
+        {
+            "description": "should not remove empty objects defined with additionalProperties",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "requiredProperty": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "requiredProperty"
+                ]
+            },
+            "valid": true
+        },
+        {
+            "description": "should not remove empty arrays",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "requiredProperty": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "requiredProperty"
+                ]
+            },
+            "valid": true
+        },
+        {
+            "description": "should not remove empty objects",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "requiredProperty": {
+                        "type": "object",
+                        "properties": {
+                            "optionalProperty": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "requiredProperty"
+                ]
+            },
+            "valid": true
+        }
+    ]
+}

--- a/tests/unit/core/utils.spec.js
+++ b/tests/unit/core/utils.spec.js
@@ -140,4 +140,27 @@ describe('Utils', () => {
       expect(clone[0][0]).to.eql(clone);
     });
   });
+
+  describe('clean function', () => {
+    it('should remove undefined values', () => {
+      const a = { b: undefined, c: { d: 'string value', e: [undefined] } };
+
+      const cleaned = utils.clean(a);
+      expect(cleaned).to.eql({ c: { d: 'string value', e: [] } });
+    });
+
+    it('should return same value if not passed an object', () => {
+      expect(utils.clean(null)).to.eql(null);
+      expect(utils.clean('string value')).to.eql('string value');
+      expect(utils.clean(undefined)).to.eql(undefined);
+      expect(utils.clean(123)).to.eql(123);
+    });
+
+    it('should respect required keys when removing empty objects', () => {
+      const a = { b: {}, c: { d: 'string value' }, e: {} };
+
+      const cleaned = utils.clean(a, ['b']);
+      expect(cleaned).to.eql({ b: {}, c: { d: 'string value' } });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #569 by cleaning up empty and undefined values while the schema is being traversed, so required values are taken into account and not removed.