### PR TITLE
Fix removing optional empty objects for `oneOf` and `anyOf` schemas

### DIFF
--- a/src/lib/core/run.js
+++ b/src/lib/core/run.js
@@ -173,7 +173,8 @@ function run(refs, schema, container) {
             mix.forEach(omit => {
               if (omit.required && omit !== fixed) {
                 omit.required.forEach(key => {
-                  if (copy.properties && !copy.required.includes(key)) {
+                  const includesKey = copy.required && copy.required.includes(key);
+                  if (copy.properties && !includesKey) {
                     delete copy.properties[key];
                   }
 

--- a/src/lib/core/traverse.js
+++ b/src/lib/core/traverse.js
@@ -51,8 +51,8 @@ function traverse(schema, path, resolve, rootSchema) {
 
   // thunks can return sub-schemas
   if (typeof schema.thunk === 'function') {
-    const traverseResult = traverse(schema.thunk(rootSchema), path, resolve);
-    return utils.clean(traverseResult, schema.required || [], false);
+    // result is already cleaned in thunk
+    return traverse(schema.thunk(rootSchema), path, resolve);
   }
 
   if (typeof schema.generate === 'function') {

--- a/tests/schema/core/issues/issue-569.json
+++ b/tests/schema/core/issues/issue-569.json
@@ -56,6 +56,38 @@
                 ]
             },
             "valid": true
+        },
+        {
+            "description": "should not remove empty objects when required by oneOf but not by root schema",
+            "schema": {
+                "type": "object",
+                "required": [
+                    "id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "oneOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "object",
+                                "properties": {}
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "name"
+                        ]
+                    }
+                ]
+            },
+            "valid": true
         }
     ]
 }


### PR DESCRIPTION
Another PR relating to issue #569 

For `oneOf` and `anyOf` schemas, the cleanup of empty objects is handled in the subschemas `thunk` function at which point we have knowledge of both the root schema's `required` properties and the given `oneOf` or `anyOf` schema's required properties. Otherwise, neither of these required properties would be taken into account.