### PR TITLE
Fix removing required objects in objects with `additionalProperties`

### DIFF
--- a/src/lib/core/traverse.js
+++ b/src/lib/core/traverse.js
@@ -45,7 +45,7 @@ function traverse(schema, path, resolve, rootSchema) {
     // build new object value from not-schema!
     if (schema.type && schema.type === 'object') {
       const traverseResult = traverse(schema, path.concat(['not']), resolve, rootSchema);
-      return utils.clean(traverseResult, schema.required || [], false);
+      return utils.clean(traverseResult, schema, false);
     }
   }
 
@@ -113,7 +113,8 @@ function traverse(schema, path, resolve, rootSchema) {
 
   Object.keys(schema).forEach(prop => {
     if (typeof schema[prop] === 'object' && prop !== 'definitions') {
-      copy[prop] = utils.clean(traverse(schema[prop], path.concat([prop]), resolve, copy), schema[prop].required || [], false);
+      const traverseResult = traverse(schema[prop], path.concat([prop]), resolve, copy);
+      copy[prop] = utils.clean(traverseResult, schema[prop], false);
     } else {
       copy[prop] = schema[prop];
     }

--- a/tests/schema/core/issues/issue-569.json
+++ b/tests/schema/core/issues/issue-569.json
@@ -88,6 +88,41 @@
                 ]
             },
             "valid": true
+        },
+        {
+            "description": "should not remove empty objects described in additionalProperties",
+            "schema": {
+                "type": "object",
+                "minProperties": 1,
+                "additionalProperties": {
+                    "required": [
+                        "id"
+                    ],
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        }
+                    },
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "type": {
+                                    "type": "object",
+                                    "properties": {}
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "name"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "valid": true
         }
     ]
 }

--- a/tests/unit/core/utils.spec.js
+++ b/tests/unit/core/utils.spec.js
@@ -159,7 +159,7 @@ describe('Utils', () => {
     it('should respect required keys when removing empty objects', () => {
       const a = { b: {}, c: { d: 'string value' }, e: {} };
 
-      const cleaned = utils.clean(a, ['b']);
+      const cleaned = utils.clean(a, { required: ['b'] });
       expect(cleaned).to.eql({ b: {}, c: { d: 'string value' } });
     });
   });


### PR DESCRIPTION
Last one related to #569, I promise!

Uses whole schema based to conclude if an empty object should be removed. If the object was generated with a `thunk` subroutine, it's assumed that the object was already cleaned.