### PR TITLE
Cleanup documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,20 +12,20 @@ If you are submitting a bug report, please include the following:
 
 * When submitting *bug reports*, *paste your schema example* whenever possible. This will save us from having to ask you for it later.
 * When submitting *Pull Requests (PRs)*, you should request to merge your changes into our `develop` branch.
-* Our approach to testing is described in [spec/README.md](/spec/README.md).
+* Our approach to testing is described in [docs/TESTING.md](/docs/TESTING.md).
 * PRs without specs will not be merged anytime soon!
 
 ## Releasing new versions
 
 * Create a new entry in the [CHANGELOG](/CHANGELOG) file,
-* Re-build and re-release the online demo, see [`website-jsf` gh-pages branch](https://github.com/json-schema-faker/website-jsf/tree/gh-pages).
+* Re-build and re-release the online demo, see [`json-schema-faker` gh-pages branch](https://github.com/json-schema-faker/json-schema-faker/tree/gh-pages).
 
 ## Development tasks
 
 * `npm run dev` &mdash; Run the tests and watch (preferred during development)
-* `npm run dev:lint` &mdash; Run eslint on all sources
-* `npm run dev:unit` &mdash; Run `jasmine-node` on unit tests
-* `npm run dev:schema` &mdash; Run `jasmine-node` on schema tests
+* `npm run lint` &mdash; Run eslint on all sources
+* `npm run test:unit` &mdash; Run unit tests
+* `npm run test:schema` &mdash; Run schema tests
 * `npm run cover` &mdash; Run istanbul + jasmine-node
 * `npm run cover:up` &mdash; Upload to coveralls (CI only)
 * `npm run dist` &mdash; Prepare all assets with locales for CDN support

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,7 +4,6 @@
   - [Overview](#overview)
   - [Example usage](#example-usage)
     - [More examples](#more-examples)
-    - [Gist demos](#gist-demos)
   - [Automation](#automation)
     - [Angular-jsf (AngularJS plugin)](#angular-jsf)
     - [Grunt plugin](#grunt-plugin)
@@ -350,7 +349,7 @@ jsf.option('alwaysFakeOptionals', true);
 
 ## Extending dependencies
 
-You may extend [Faker.js](http://marak.com/faker.js/):
+You may extend [Faker.js](https://github.com/Marak/faker.js):
 
 ```javascript
 import jsf from 'json-schema-faker';


### PR DESCRIPTION
Update links and documented npm scripts. There were some documented npm scripts that didn't look right but I didn't know how to update them: `npm run cover`, `npm run cover:up`, and `npm run dist`.