### PR TITLE
Make .only a linter error in unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1792,6 +1792,33 @@
         }
       }
     },
+    "eslint-plugin-mocha": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.3.0.tgz",
+      "integrity": "sha512-Cd2roo8caAyG21oKaaNTj7cqeYRWW1I2B5SfpKRp0Ip1gkfwoR1Ow0IGlPWnNjzywdF4n+kHL8/9vM6zCJUxdg==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "ramda": "^0.27.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-svelte3": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-svelte3/-/eslint-plugin-svelte3-2.7.3.tgz",
@@ -4478,6 +4505,12 @@
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
+    },
+    "ramda": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
+      "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==",
+      "dev": true
     },
     "randexp": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "eslint": "^6.0.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.0",
+    "eslint-plugin-mocha": "6.3.0",
     "eslint-plugin-svelte3": "^2.7.3",
     "esm": ">=3.1.0",
     "faker": "^4.1.0",

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -3,7 +3,11 @@
   "env": {
     "mocha": true
   },
+  "plugins": [
+    "mocha"
+  ],
   "rules": {
+    "mocha/no-exclusive-tests": "error",
     "no-unused-expressions": 0
   }
 }


### PR DESCRIPTION
I almost pushed a .only earlier, so I'm making sure that won't pass CI.