### PR TITLE
Fix nested oneOf allOf

### DIFF
--- a/src/lib/core/run.js
+++ b/src/lib/core/run.js
@@ -184,6 +184,9 @@ function run(refs, schema, container) {
           utils.merge(sub, typeof _sub.thunk === 'function'
             ? _sub.thunk(sub)
             : _sub);
+          if (Array.isArray(sub.allOf)) {
+            reduce(sub, index, rootPath);
+          }
         });
       }
 

--- a/tests/schema/core/issues/all-of-one-of-all-of-nested.json
+++ b/tests/schema/core/issues/all-of-one-of-all-of-nested.json
@@ -1,0 +1,70 @@
+[
+  {
+    "description": "allOf oneOf allOff nested",
+    "schemas": [{
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "date_of_birth": {
+          "type": "string",
+          "minimum": 10,
+          "maximum": 10
+        },
+        "age_group": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 5
+        }
+      },
+
+      "allOf": [{
+        "oneOf": [{
+          "allOf": [{
+            "type": "object",
+            "required": ["a"],
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            }
+          },{
+            "type": "object",
+            "required": ["b"],
+            "properties": {
+              "b": {
+                "type": "string"
+              }
+            }
+          }]
+        }, {
+          "allOf": [{
+            "type": "object",
+            "required": ["a"],
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            }
+          },{
+            "type": "object",
+            "required": ["c"],
+            "properties": {
+              "c": {
+                "type": "string"
+              }
+            }
+          }]
+        }]
+      }]
+    }],
+    "tests": [
+      {
+        "description": "should combine recursively",
+        "schema": "schemas.0",
+        "valid": true,
+        "hasProps": ["a"]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
While using prism, which relies on jsf, for dynamicly mocking an api from a open api specification file, I encountered strange behaviour:
If the schema has a nested objects: The root object has a allOf which contains a oneOf which contains a allOf, than the properties form the last one are missing (example schema in the test commit).
I fixed the bug by calling reduce again if the object contains another allOf after merge. I am not quite sure if that has any side effects, but that fix solves my probleme and all tests passed.