### PR TITLE
Move reduce to a new file so it can be unit tested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -287,6 +287,51 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
@@ -3152,6 +3197,12 @@
         "promise": "^7.0.1"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3526,6 +3577,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-environment-flags": {
       "version": "1.0.6",
@@ -4134,6 +4198,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -5005,6 +5086,50 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "sinon-chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
+      "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
       "dev": true
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,8 @@
     "seedrandom": "^3.0.1",
     "semver": "^7.1.1",
     "serialize-javascript": ">=2.1.1",
+    "sinon": "9.0.2",
+    "sinon-chai": "3.5.0",
     "svelte": "^3.19.1",
     "svql": "^0.0.27",
     "tarima": "^4.7.2",

--- a/src/lib/core/buildResolveSchema.js
+++ b/src/lib/core/buildResolveSchema.js
@@ -1,0 +1,142 @@
+import optionAPI from '../api/option';
+import random from './random';
+import utils from './utils';
+
+const buildResolveSchema = ({
+  refs,
+  schema,
+  container,
+  refDepthMax,
+  refDepthMin,
+}) => {
+  let depth = 0;
+  let lastRef;
+
+  const recursiveUtil = {};
+  recursiveUtil.resolveSchema = (sub, index, rootPath) => {
+    if (typeof sub.generate === 'function') {
+      return sub;
+    }
+
+    // cleanup
+    const _id = sub.$id || sub.id;
+
+    if (typeof _id === 'string') {
+      delete sub.id;
+      delete sub.$id;
+      delete sub.$schema;
+    }
+
+    if (typeof sub.$ref === 'string') {
+      const maxDepth = Math.max(refDepthMin, refDepthMax) - 1;
+
+      // increasing depth only for repeated refs seems to be fixing #258
+      if (sub.$ref === '#' || (lastRef === sub.$ref && ++depth > maxDepth)) {
+        delete sub.$ref;
+        return sub;
+      }
+
+      lastRef = sub.$ref;
+
+      let ref;
+
+      if (sub.$ref.indexOf('#/') === -1) {
+        ref = refs[sub.$ref] || null;
+      }
+
+      if (sub.$ref.indexOf('#/definitions/') === 0) {
+        ref = schema.definitions[sub.$ref.split('#/definitions/')[1]] || null;
+      }
+
+      if (typeof ref !== 'undefined') {
+        if (!ref && optionAPI('ignoreMissingRefs') !== true) {
+          throw new Error(`Reference not found: ${sub.$ref}`);
+        }
+
+        utils.merge(sub, ref || {});
+      }
+
+      // just remove the reference
+      delete sub.$ref;
+      return sub;
+    }
+
+    if (Array.isArray(sub.allOf)) {
+      const schemas = sub.allOf;
+
+      delete sub.allOf;
+
+      // this is the only case where all sub-schemas
+      // must be resolved before any merge
+      schemas.forEach(subSchema => {
+        const _sub = recursiveUtil.resolveSchema(subSchema, null, rootPath);
+
+        // call given thunks if present
+        utils.merge(sub, typeof _sub.thunk === 'function'
+          ? _sub.thunk(sub)
+          : _sub);
+        if (Array.isArray(sub.allOf)) {
+          recursiveUtil.resolveSchema(sub, index, rootPath);
+        }
+      });
+    }
+
+    if (Array.isArray(sub.oneOf || sub.anyOf)) {
+      const mix = sub.oneOf || sub.anyOf;
+
+      // test every value from the enum against each-oneOf
+      // schema, only values that validate once are kept
+      if (sub.enum && sub.oneOf) {
+        sub.enum = sub.enum.filter(x => utils.validate(x, mix));
+      }
+
+      return {
+        thunk(rootSchema) {
+          const copy = utils.omitProps(sub, ['anyOf', 'oneOf']);
+          const fixed = random.pick(mix);
+
+          utils.merge(copy, fixed);
+
+          // remove additional properties from merged schemas
+          mix.forEach(omit => {
+            if (omit.required && omit !== fixed) {
+              omit.required.forEach(key => {
+                const includesKey = copy.required && copy.required.includes(key);
+                if (copy.properties && !includesKey) {
+                  delete copy.properties[key];
+                }
+
+                if (rootSchema && rootSchema.properties) {
+                  delete rootSchema.properties[key];
+                }
+              });
+            }
+          });
+
+          return copy;
+        },
+      };
+    }
+
+    Object.keys(sub).forEach(prop => {
+      if ((Array.isArray(sub[prop]) || typeof sub[prop] === 'object') && !utils.isKey(prop)) {
+        sub[prop] = recursiveUtil.resolveSchema(sub[prop], prop, rootPath.concat(prop));
+      }
+    });
+
+    // avoid extra calls on sub-schemas, fixes #458
+    if (rootPath) {
+      const lastProp = rootPath[rootPath.length - 1];
+
+      if (lastProp === 'properties' || lastProp === 'items') {
+        return sub;
+      }
+    }
+
+    return container.wrap(sub);
+  };
+
+  return recursiveUtil;
+};
+
+export default buildResolveSchema;

--- a/src/lib/core/run.js
+++ b/src/lib/core/run.js
@@ -4,6 +4,7 @@ import optionAPI from '../api/option';
 import traverse from './traverse';
 import random from './random';
 import utils from './utils';
+import buildResolveSchema from './buildResolveSchema';
 
 function pick(data) {
   return Array.isArray(data)
@@ -82,134 +83,18 @@ function resolve(obj, data, values, property) {
 
 // TODO provide types
 function run(refs, schema, container) {
-  let depth = 0;
   const refDepthMin = optionAPI('refDepthMin') || 0;
   const refDepthMax = optionAPI('refDepthMax') || 3;
-  let lastRef;
 
   try {
-    const result = traverse(utils.clone(schema), [], function reduce(sub, index, rootPath) {
-      if (typeof sub.generate === 'function') {
-        return sub;
-      }
-
-      // cleanup
-      const _id = sub.$id || sub.id;
-
-      if (typeof _id === 'string') {
-        delete sub.id;
-        delete sub.$id;
-        delete sub.$schema;
-      }
-
-      if (typeof sub.$ref === 'string') {
-        const maxDepth = Math.max(refDepthMin, refDepthMax) - 1;
-
-        // increasing depth only for repeated refs seems to be fixing #258
-        if (sub.$ref === '#' || (lastRef === sub.$ref && ++depth > maxDepth)) {
-          delete sub.$ref;
-          return sub;
-        }
-
-        lastRef = sub.$ref;
-
-        let ref;
-
-        if (sub.$ref.indexOf('#/') === -1) {
-          ref = refs[sub.$ref] || null;
-        }
-
-        if (sub.$ref.indexOf('#/definitions/') === 0) {
-          ref = schema.definitions[sub.$ref.split('#/definitions/')[1]] || null;
-        }
-
-        if (typeof ref !== 'undefined') {
-          if (!ref && optionAPI('ignoreMissingRefs') !== true) {
-            throw new Error(`Reference not found: ${sub.$ref}`);
-          }
-
-          utils.merge(sub, ref || {});
-        }
-
-        // just remove the reference
-        delete sub.$ref;
-        return sub;
-      }
-
-      if (Array.isArray(sub.allOf)) {
-        const schemas = sub.allOf;
-
-        delete sub.allOf;
-
-        // this is the only case where all sub-schemas
-        // must be resolved before any merge
-        schemas.forEach(subSchema => {
-          const _sub = reduce(subSchema, null, rootPath);
-
-          // call given thunks if present
-          utils.merge(sub, typeof _sub.thunk === 'function'
-            ? _sub.thunk(sub)
-            : _sub);
-          if (Array.isArray(sub.allOf)) {
-            reduce(sub, index, rootPath);
-          }
-        });
-      }
-
-      if (Array.isArray(sub.oneOf || sub.anyOf)) {
-        const mix = sub.oneOf || sub.anyOf;
-
-        // test every value from the enum against each-oneOf
-        // schema, only values that validate once are kept
-        if (sub.enum && sub.oneOf) {
-          sub.enum = sub.enum.filter(x => utils.validate(x, mix));
-        }
-
-        return {
-          thunk(rootSchema) {
-            const copy = utils.omitProps(sub, ['anyOf', 'oneOf']);
-            const fixed = random.pick(mix);
-
-            utils.merge(copy, fixed);
-
-            // remove additional properties from merged schemas
-            mix.forEach(omit => {
-              if (omit.required && omit !== fixed) {
-                omit.required.forEach(key => {
-                  const includesKey = copy.required && copy.required.includes(key);
-                  if (copy.properties && !includesKey) {
-                    delete copy.properties[key];
-                  }
-
-                  if (rootSchema && rootSchema.properties) {
-                    delete rootSchema.properties[key];
-                  }
-                });
-              }
-            });
-
-            return copy;
-          },
-        };
-      }
-
-      Object.keys(sub).forEach(prop => {
-        if ((Array.isArray(sub[prop]) || typeof sub[prop] === 'object') && !utils.isKey(prop)) {
-          sub[prop] = reduce(sub[prop], prop, rootPath.concat(prop));
-        }
-      });
-
-      // avoid extra calls on sub-schemas, fixes #458
-      if (rootPath) {
-        const lastProp = rootPath[rootPath.length - 1];
-
-        if (lastProp === 'properties' || lastProp === 'items') {
-          return sub;
-        }
-      }
-
-      return container.wrap(sub);
+    const { resolveSchema } = buildResolveSchema({
+      refs,
+      schema,
+      container,
+      refDepthMin,
+      refDepthMax,
     });
+    const result = traverse(utils.clone(schema), [], resolveSchema);
 
     if (optionAPI('resolveJsonPath')) {
       return resolve(result);

--- a/tests/unit/core/buildResolveSchema.test.js
+++ b/tests/unit/core/buildResolveSchema.test.js
@@ -1,0 +1,215 @@
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import buildResolveSchema from '../../../src/lib/core/buildResolveSchema';
+import Container from '../../../src/lib/class/Container';
+
+chai.use(sinonChai);
+const { expect } = chai;
+
+describe('lib/core/buildResolveSchema->resolveSchema', () => {
+  const { resolveSchema: basicResolveSchema } = buildResolveSchema({
+    container: new Container(),
+  });
+
+  context('when the schema has a "generate" key', () => {
+    // TODO: figure out when this would happen
+    it('returns the schema');
+  });
+
+  context('when the schema has an id', () => {
+    it('removes the id and $schema properties', () => {
+      const schema = {
+        id: 'abc',
+        $schema: {},
+      };
+
+      const result = basicResolveSchema(schema);
+
+      expect(result).to.equal(schema);
+      expect(result).to.eql({});
+    });
+  });
+
+  context('when the schema has an $id', () => {
+    it('removes the $id and $schema properties', () => {
+      const schema = {
+        $id: 'abc',
+        $schema: {},
+      };
+
+      const result = basicResolveSchema(schema);
+
+      expect(result).to.equal(schema);
+      expect(result).to.eql({});
+    });
+  });
+
+  // TODO: test a $ref schema and all of its variations
+  context('when the schema is a $ref schema', () => {
+    it('... test cases pending');
+  });
+
+  context('when the schema has an allOf', () => {
+    const recursiveUtil = buildResolveSchema({
+      container: new Container(),
+    });
+    const schema = {
+      allOf: [
+        {
+          type: 'string',
+          minLength: 2,
+        },
+        {
+          type: 'string',
+          maxLength: 4,
+        },
+      ],
+    };
+    let result;
+
+    before(() => {
+      sinon.spy(recursiveUtil, 'resolveSchema');
+
+      result = recursiveUtil.resolveSchema(schema, null, ['test', 'path']);
+    });
+
+    it('resolves the inner schemas', () => {
+      expect(recursiveUtil.resolveSchema).to.be.calledThrice;
+      expect(recursiveUtil.resolveSchema).to.be.calledWithExactly({ type: 'string', minLength: 2 }, null, ['test', 'path']);
+      expect(recursiveUtil.resolveSchema).to.be.calledWithExactly({ type: 'string', maxLength: 4 }, null, ['test', 'path']);
+    });
+
+    // TODO: test when some inner schemas are thunk schemas
+    it('resolves inner thunk schemas with the parent schema');
+
+    it('merges the allOf schemas into the sub schema', () => {
+      expect(result).to.equal(schema);
+      expect(result).to.eql({
+        type: 'string',
+        minLength: 2,
+        maxLength: 4,
+      });
+    });
+
+    it('deletes the allOf from the schema', () => {
+      expect(schema.allOf).to.be.undefined;
+    });
+  });
+
+  context('when the schema has a oneOf', () => {
+    let result;
+    before(() => {
+      const schema = {
+        anyOf: [],
+      };
+      result = basicResolveSchema(schema, null, ['test', 'path']);
+    });
+
+    it('returns a schema with a thunk', () => {
+      expect(result).to.be.an('object').with.property('thunk').that.is.a('function');
+    });
+  });
+
+  context('when the schema has a oneOf and an enum', () => {
+    const schema = {
+      enum: [1, 2, 3, 4, 5],
+      oneOf: [
+        { minimum: 2 },
+        { maximum: 4 },
+      ],
+    };
+    let result;
+
+    before(() => {
+      result = basicResolveSchema(schema, null, ['test', 'path']);
+    });
+
+    it('returns a schema with a thunk', () => {
+      expect(result).to.be.an('object').with.property('thunk').that.is.a('function');
+    });
+
+    it('modifies the enum', () => {
+      expect(schema.enum).to.eql([1, 5]);
+    });
+  });
+
+  context('when the schema has an anyOf', () => {
+    let result;
+    before(() => {
+      const schema = {
+        oneOf: [],
+      };
+      result = basicResolveSchema(schema, null, ['test', 'path']);
+    });
+
+    it('returns a schema with a thunk', () => {
+      expect(result).to.be.an('object').with.property('thunk').that.is.a('function');
+    });
+  });
+
+  context('when a schema has an array property that is not a json-schema key', () => {
+    const recursiveUtil = buildResolveSchema({
+      container: new Container(),
+    });
+    const schema = {
+      exampleProp: ['example array value'],
+    };
+
+    before(() => {
+      sinon.spy(recursiveUtil, 'resolveSchema');
+
+      recursiveUtil.resolveSchema(schema, null, ['test', 'path']);
+    });
+
+    it('resolves the property value as if it was a schema', () => {
+      expect(recursiveUtil.resolveSchema).to.be.calledTwice;
+      expect(recursiveUtil.resolveSchema).to.be.calledWithExactly(['example array value'], 'exampleProp', ['test', 'path', 'exampleProp']);
+    });
+  });
+
+  context('when a schema has an object property that is not a json-schema key', () => {
+    const recursiveUtil = buildResolveSchema({
+      container: new Container(),
+    });
+    const schema = {
+      exampleProp: { exampleInnerKey: 'example inner value' },
+    };
+
+    before(() => {
+      sinon.spy(recursiveUtil, 'resolveSchema');
+
+      recursiveUtil.resolveSchema(schema, null, ['test', 'path']);
+    });
+
+    it('resolves the property value as if it was a schema', () => {
+      expect(recursiveUtil.resolveSchema).to.be.calledTwice;
+      expect(recursiveUtil.resolveSchema).to.be.calledWithExactly(
+        { exampleInnerKey: 'example inner value' },
+        'exampleProp',
+        ['test', 'path', 'exampleProp'],
+      );
+    });
+  });
+
+  context('when the function does not return for any other reason', () => {
+    const container = new Container();
+    const mockWrapReturnValue = Symbol('mockWrapReturn');
+    let result;
+
+    before(() => {
+      sinon.stub(container, 'wrap').returns(mockWrapReturnValue);
+      const { resolveSchema } = buildResolveSchema({ container });
+      result = resolveSchema({ someKey: 'some value' }, null, ['test', 'path']);
+    });
+
+    it('wraps the schema', () => {
+      expect(container.wrap).to.be.called
+        .and.to.be.calledWithExactly({ someKey: 'some value' });
+    });
+
+    it('returns the wrapped schema', () => {
+      expect(result).to.equal(mockWrapReturnValue);
+    });
+  });
+});


### PR DESCRIPTION
Moving the `reduce` function from the `run` file to a `buildResolveSchema` file so that it can be unit tested. `buildResolveSchema` is a function that returns an object with a function called `resolveSchema`. This allows `resolveSchema` to be stubbed in the unit tests so its recursive behavior can be asserted on. 

Please not that `reduce` was moved to `resolveSchema` in its entirety. f2a162010d7e7acaf510a33778e555823e8f7434 simply moves the function without changing any of the behavior.

I was not able to test everything, but writing the tests has helped me understand more about the library 😄 