### PR TITLE
feature/allow-null-values

### DIFF
--- a/src/lib/core/run.js
+++ b/src/lib/core/run.js
@@ -123,6 +123,11 @@ function run(refs, schema, container) {
 
   try {
     const result = traverse(utils.clone(schema), [], function reduce(sub, index, rootPath) {
+      // prevent null sub from default/example null values to throw
+      if (sub === null || sub === undefined) {
+        return null;
+      }
+
       if (typeof sub.generate === 'function') {
         return sub;
       }

--- a/src/lib/core/utils.js
+++ b/src/lib/core/utils.js
@@ -102,6 +102,11 @@ function typecast(type, schema, callback) {
   // execute generator
   let value = callback(params);
 
+  // allow null values to be returned
+  if (value === null || value === undefined) {
+    return null;
+  }
+
   // normalize output value
   switch (type || schema.type) {
     case 'number':


### PR DESCRIPTION
**Feature**: allow null values in example/default schema section to be returned as valid values:

Allowing null values to be returned as a valid value (which is very common in APIs) has been done in the *core.utils.typecast* function. Adding a control on null/undefined value once the value is extracted from the params makes it now possible to deal with null values.

**Fix**: an example or default value set to null in a schema can make *core.run* function throw when traversing the schema (line 125):

```javascript
const result = traverse(utils.clone(schema), [], function reduce(sub, index, rootPath) {
    if (typeof sub.generate === 'function') {
        return sub;
    }
```

In this case sub would be de facto null or undefined and `typeof sub.generate === 'function'` will throw. Adding a control on null/undefined sub fixes this.

**Tests**: green, no regression. Please let me know if any unexpected issue could be found regarding this feature as I have not enough vision around this project.

Thx ;)