### PR TITLE
Support definitions from different file

### DIFF
--- a/src/lib/core/buildResolveSchema.js
+++ b/src/lib/core/buildResolveSchema.js
@@ -49,7 +49,7 @@ const buildResolveSchema = ({
         ref = refs[sub.$ref] || null;
       }
 
-      if (sub.$ref.indexOf('#/definitions/') === 0) {
+      if (sub.$ref.indexOf('#/definitions/') >= 0) {
         ref = schema.definitions[sub.$ref.split('#/definitions/')[1]] || null;
       }
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -91,6 +91,9 @@ const jsf = (schema, refs, cwd) => {
 };
 
 jsf.generate = (schema, refs) => {
+  if (Array.isArray(schema)) {
+    schema = Object.assign(...schema)
+  }
   const $refs = getRefs(refs, schema);
 
   return run($refs, schema, container);


### PR DESCRIPTION
json-schema-faker doesn't handle ```$ref``` to a different file. This change fix it 

Exmaple

```json5
// common.schema.json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "id": "common.schema.json",
  "definitions" : {
    "logging": {
      "$id": "#/properties/logging",
      "type": "object",
      "title": "Logging Configuration",
      "required": [
        "level"
      ],
      "additionalProperties": false,
      "properties": {
        "level": {
          "$id": "#/properties/logging/properties/level",
          "type": "string",
          "title": "Log severity level",
          "default": "info",
          "examples": [
            "info"
          ],
          "enum": [
            "error",   "warn",
            "info",    "http",
            "verbose", "debug",
            "silly"
          ]
        },
        "silent": {
          "$id": "#/properties/logging/properties/silent",
          "type": "boolean",
          "title": "Is Silent",
          "description": "If true, all logging is disabled",
          "default": false,
          "examples": [
            false
          ]
        },
        
      }
    }
}
```
```json5
{
// Schema.json
  "$schema": "http://json-schema.org/draft-07/schema#",
  "$id": "cdvr.config.schema.json",
  "type": "object",
  "properties": {
    "logging": { "$ref" : "common.schema.json#/definitions/logging"}
}
```
```javascript
// main.js
    const schema= require("config.schema.json")
    const schemaRefs= require("common.schema.json")
    const sample = jsf.generate([schema,schemaRefs])
