### PR TITLE
Type checks for arrays in values returned by generator

### DIFF
--- a/src/lib/core/traverse.js
+++ b/src/lib/core/traverse.js
@@ -59,7 +59,7 @@ function traverse(schema, path, resolve, rootSchema) {
     const retval = utils.typecast(null, schema, () => schema.generate(rootSchema, path));
     const type = typeof retval;
 
-    if (type === schema.type || (type === 'number' && schema.type === 'integer')) {
+    if (type === schema.type || (type === 'number' && schema.type === 'integer') || (Array.isArray(retval) && schema.type === 'array')) {
       return retval;
     }
   }


### PR DESCRIPTION
In JS `typeof [] === 'object'`.

It means that for `schema.type === 'array'` this checks https://github.com/json-schema-faker/json-schema-faker/blob/master/src/lib/core/traverse.js#L62 are always going to be false.