### PR TITLE
add support for `contains` in arrays

### DIFF
--- a/src/lib/types/array.js
+++ b/src/lib/types/array.js
@@ -108,6 +108,11 @@ function arrayType(value, path, resolve, traverseCallback) {
     items.push(element);
   }
 
+  if (value.contains && length > 0) {
+    const idx = random.number(0, length - 1);
+    items[idx] = traverseCallback(value.contains, path.concat(["items",idx]), resolve);
+  }
+
   if (value.uniqueItems) {
     return unique(path.concat(['items']), items, value, sample, resolve, traverseCallback);
   }

--- a/tests/schema/core/issues/issue-585.json
+++ b/tests/schema/core/issues/issue-585.json
@@ -1,0 +1,53 @@
+[
+  {
+    "description": "Support 'content' for arrays",
+    "tests": [
+      {
+        "description": "should handle content with empty array",
+        "schema": {
+          "type": "array",
+          "minItems": 0,
+          "maxItems": 0,
+          "items": {
+            "type": "integer"
+          },
+          "contains": {
+            "const": 42
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "should handle content with single item array",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 1,
+          "maxItems": 1,
+          "contains": {
+            "const": 42
+          }
+        },
+        "equal": [42]
+      },
+      {
+        "description": "should handle content with any array length",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 2,
+          "maxItems": 10,
+          "contains": {
+            "const": 42
+          }
+        },
+        "repeat": 10,
+        "valid": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Simply replaces one index of the generated array with an item that matches the `contains` schema.

Resolves #585 