### PR TITLE
feat: enhance context with schema path

### DIFF
--- a/tests/unit/core/traverse.spec.js
+++ b/tests/unit/core/traverse.spec.js
@@ -23,14 +23,17 @@ describe('Traverse', () => {
       additionalProperties: false,
     };
 
-    expect(traverse(schema, '', mockResolve, schema)).to.eql({
+    expect(traverse(schema, [], mockResolve, schema)).to.eql({
       value: {
         foo: 0,
       },
       context: {
+        schemaPath: [],
         description: schema.description,
         items: {
+          schemaPath: ['properties'],
           foo: {
+            schemaPath: ['properties', 'foo'],
             title: schema.properties.foo.title,
             description: schema.properties.foo.description,
           },
@@ -39,7 +42,7 @@ describe('Traverse', () => {
     });
   });
 
-  it('array value and context', () => {
+  it('array list value and context', () => {
     const schema = {
       title: 'Foo array',
       type: 'array',
@@ -51,15 +54,51 @@ describe('Traverse', () => {
       maxItems: 1,
     };
 
-    expect(traverse(schema, '', mockResolve, schema)).to.eql({
+    expect(traverse(schema, [], mockResolve, schema)).to.eql({
       value: ['foo'],
       context: {
+        schemaPath: [],
         title: schema.title,
         items: [
           {
-          description: schema.items.description,
+            schemaPath: ['items'],
+            description: schema.items.description,
+          },
+        ],
+      },
+    });
+  });
+
+  it('array tuple value and context', () => {
+    const schema = {
+      type: 'array',
+      items: [
+        {
+          title: 'Always zero',
+          const: 0,
         },
-          ],
+        {
+          description: 'Some string',
+          type: 'string',
+          generate: () => 'foo',
+        },
+      ],
+    };
+
+    expect(traverse(schema, [], mockResolve, schema)).to.eql({
+      value: [0, 'foo'],
+      context: {
+        schemaPath: [],
+        items: [
+          {
+            schemaPath: ['items', 0],
+            title: schema.items[0].title,
+          },
+          {
+            schemaPath: ['items', 1],
+            description: schema.items[1].description,
+          },
+        ],
       },
     });
   });


### PR DESCRIPTION
This change allows one to use the `schemaPath` from the context to get additional information from the schema. An alternative would be to copy more fields into the context, but that will eventually end up with a full schema copy in the context. By adding the `schemaPath`, it is possible for everyone to get the information they need.