### PR TITLE
Fix nested refs when running sync

### DIFF
--- a/src/lib/core/buildResolveSchema.js
+++ b/src/lib/core/buildResolveSchema.js
@@ -63,17 +63,22 @@ const buildResolveSchema = ({
         ref = utils.getLocalRef(schema, sub.$ref, synchronous && refs) || null;
       }
 
+      let fixed;
       if (typeof ref !== 'undefined') {
         if (!ref && optionAPI('ignoreMissingRefs') !== true) {
           throw new Error(`Reference not found: ${sub.$ref}`);
         }
 
         seenRefs[sub.$ref] -= 1;
+        fixed = ref && ref.$ref;
         utils.merge(sub, ref || {});
       }
 
-      // just remove the reference
-      delete sub.$ref;
+      if (!fixed) {
+        // just remove the reference
+        delete sub.$ref;
+      }
+
       return sub;
     }
 

--- a/tests/schema/core/issues/nested-refs.json
+++ b/tests/schema/core/issues/nested-refs.json
@@ -1,0 +1,30 @@
+{
+  "description": "nested $refs",
+  "tests": [
+    {
+      "description": "should follow nested $refs in synchronous mode",
+      "sync": true,
+      "schema": {
+        "type": "object",
+        "properties": {
+          "hello": {
+            "$ref": "#/definitions/middle"
+          }
+        },
+        "required": ["hello"],
+        "definitions": {
+          "middle": {
+            "$ref": "#/definitions/world"
+          },
+          "world": {
+            "type": "string",
+            "const": "world!"
+          }
+        }
+      },
+      "equal": {
+        "hello": "world!"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
json-schema-faker currently doesn't follow nested `$ref`s correctly when using `generate`.

Current behaviour:

```
  1) nested $refs (tests/schema/core/issues/nested-refs.json)
       should follow nested $refs in synchronous mode:

      AssertionError: expected { hello: {} } to deeply equal { hello: 'world!' }
      + expected - actual

       {
      -  "hello": {}
      +  "hello": "world!"
       }
```

This only happens when running `generate`, `resolve` doesn't have this issue.

𖤐🤘😈🤘𖤐