### PR TITLE
Suport for property example as single value

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,7 @@ jsf.locate('faker');
 - `alwaysFakeOptionals` &mdash; When enabled, it will set `optionalsProbability: 1.0` and ` fixedProbabilities: true` (default: `false`)
 - `optionalsProbability` &mdash; A value from `0.0` to `1.0` to generate values in a consistent way, e.g. `0.5` will generate from `0%` to `50%` of values. Using arrays it means items, on objects they're properties, etc. (default: `false`)
 - `fixedProbabilities` &mdash; If enabled, then `optionalsProbability: 0.5` will always generate the half of values (default: `false`)
-- `useExamplesValue` &mdash; If enabled, it will return a random value from `examples` if they're present (default: `false`)
+- `useExamplesValue` &mdash; If enabled, it will return a random value from `examples` or single value from `example` if present (default: `false`)
 - `useDefaultValue` &mdash; If enabled, it will return the `default` value if present (default: `false`)
 - `requiredOnly` &mdash; If enabled, only `required` properties will be generated (default: `false`)
 - `minItems` &mdash; Override `minItems` if it's less than this value (default: `0`)

--- a/src/lib/core/traverse.js
+++ b/src/lib/core/traverse.js
@@ -42,8 +42,8 @@ function traverse(schema, path, resolve, rootSchema) {
       return { value: utils.typecast(null, schema, () => random.pick(fixedExamples)), context };
     }
     // If schema contains single example property
-    if(optionAPI('useExamplesValue') && schema.example) {
-      return { value: utils.typecast(null, schema, () => schema.example, context };
+    if (optionAPI('useExamplesValue') && schema.example) {
+      return { value: utils.typecast(null, schema, () => schema.example), context };
     }
 
     if (optionAPI('useDefaultValue') && 'default' in schema) {

--- a/src/lib/core/traverse.js
+++ b/src/lib/core/traverse.js
@@ -41,6 +41,10 @@ function traverse(schema, path, resolve, rootSchema) {
 
       return { value: utils.typecast(null, schema, () => random.pick(fixedExamples)), context };
     }
+    // If schema contains single example property
+    if(optionAPI('useExamplesValue') && schema.example) {
+      return { value: utils.typecast(null, schema, () => schema.example, context };
+    }
 
     if (optionAPI('useDefaultValue') && 'default' in schema) {
       if (schema.default !== '' || !optionAPI('replaceEmptyByRandomValue')) {

--- a/tests/schema/core/option/useExamplesValue.json
+++ b/tests/schema/core/option/useExamplesValue.json
@@ -3,12 +3,21 @@
     "description": "useExamplesValue option",
     "tests": [
       {
-        "description": "should handle useExamplesValue option",
+        "description": "should handle useExamplesValue option with 'examples' array",
         "schema": {
           "type": "string",
           "examples": [
             "World"
           ]
+        },
+        "equal": "World",
+        "require": "core/option/useExamplesValue"
+      },
+      {
+        "description": "should handle useExamplesValue option with 'example' property",
+        "schema": {
+          "type": "string",
+          "example": "World"
         },
         "equal": "World",
         "require": "core/option/useExamplesValue"


### PR DESCRIPTION
This addition is to support JSON schemas using `example` to keep a single example for a property, comparing to the existing implementation that caters for an array of `examples`.

Change log
- Implemented check in `traverse.js` to check if `example` exists as single property and take that value if it does.
- Added test case for single `example` property