### PR TITLE
Bugfix: invalid time value toISOString

### DIFF
--- a/src/lib/core/utils.js
+++ b/src/lib/core/utils.js
@@ -56,8 +56,8 @@ function clampDate(value) {
 
   let [year, month, day] = value.split('T')[0].split('-');
 
-  month = Math.max(1, Math.min(12, month));
-  day = Math.max(1, Math.min(31, day));
+  month = `0${Math.max(1, Math.min(12, month))}`.slice(-2);
+  day = `0${Math.max(1, Math.min(31, day))}`.slice(-2);
 
   return `${year}-${month}-${day}`;
 }

--- a/src/lib/core/utils.js
+++ b/src/lib/core/utils.js
@@ -63,6 +63,30 @@ function clampDate(value) {
 }
 
 /**
+ * Normalize generated date-time values YYYY-MM-DDTHH:mm:ss to not have
+ * out of range values
+ *
+ * @param value
+ * @returns {string}
+ */
+function clampDateTime(value) {
+  if (value.includes(' ')) {
+    return new Date(value).toISOString().substr(0, 10);
+  }
+
+  let [year, month, day] = value.split('T')[0].split('-');
+  let [hour, minute, second] = value.split('T')[1].split('.')[0].split(':');
+
+  month = `0${Math.max(1, Math.min(12, month))}`.slice(-2);
+  day = `0${Math.max(1, Math.min(31, day))}`.slice(-2);
+  hour = `0${Math.max(1, Math.min(23, hour))}`.slice(-2);
+  minute = `0${Math.max(1, Math.min(59, minute))}`.slice(-2);
+  second = `0${Math.max(1, Math.min(59, second))}`.slice(-2);
+
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}.000Z`;
+}
+
+/**
  * Returns typecasted value.
  * External generators (faker, chance, casual) may return data in non-expected formats, such as string, when you might expect an
  * integer. This function is used to force the typecast. This is the base formatter for all result values.
@@ -190,7 +214,7 @@ function typecast(type, schema, callback) {
       switch (schema.format) {
         case 'date-time':
         case 'datetime':
-          value = new Date(clampDate(value)).toISOString().replace(/([0-9])0+Z$/, '$1Z');
+          value = new Date(clampDateTime(value)).toISOString().replace(/([0-9])0+Z$/, '$1Z');
           break;
 
         case 'full-date':


### PR DESCRIPTION
Introduce a new clampDateTime method to force all number parts in the string to be two-digit. Also, this method keeps the time part of the string.
Added the two-digit enforcement to the clampDate method too.

Fix #539 and fixes the base problem in #705 