### PR TITLE
sortProperties - fix compare func

### DIFF
--- a/src/lib/types/object.mjs
+++ b/src/lib/types/object.mjs
@@ -278,7 +278,7 @@ function objectType(value, path, resolve, traverseCallback) {
   if (optionAPI('sortProperties') !== null) {
     const originalKeys = Object.keys(properties);
     const sortedKeys = Object.keys(props).sort((a, b) => {
-      return optionAPI('sortProperties') ? a.localeCompare(b) : originalKeys.indexOf(b) - originalKeys.indexOf(a);
+      return optionAPI('sortProperties') ? a.localeCompare(b) : originalKeys.indexOf(a) - originalKeys.indexOf(b);
     });
 
     sortedObj = sortedKeys.reduce((memo, key) => {


### PR DESCRIPTION
sortProperties option not working properly.
If false, properties are returned in reverse order (original order should be kept).

schema:
```json
{
  "required": [
    "first",
    "second"
  ],
  "properties": {
    "first": {
      "type": "string"
    },
    "second": {
      "type": "string"
    }
  }
}
```

returns:
```json
{ 
  "second": "minim", 
  "first": "eiusmod laboris dolor ea nulla" 
}
```

expected:
```json
{ 
  "first": "eiusmod laboris dolor ea nulla",
  "second": "minim"
}
```