### PR TITLE
fix: set hasPrecision to false when type is integer, closes #743

### DIFF
--- a/src/lib/types/number.mjs
+++ b/src/lib/types/number.mjs
@@ -47,7 +47,7 @@ function numberType(value) {
     return base;
   }
 
-  return random.number(min, max, undefined, undefined, true);
+  return random.number(min, max, undefined, undefined, value.type !== 'integer');
 }
 
 export default numberType;

--- a/tests/schema/core/option/random.json
+++ b/tests/schema/core/option/random.json
@@ -23,7 +23,7 @@
         },
         "valid": true,
         "equal": {
-          "a": 43,
+          "a": 44,
           "b": "in culpa proident amet",
           "c": "fe228"
         },

--- a/tests/unit/generators/number.spec.mjs
+++ b/tests/unit/generators/number.spec.mjs
@@ -27,6 +27,11 @@ describe('Number Generator', () => {
     expect(isMultipleOf({ multipleOf: 8, minimum: 80, maximum: 90 })).to.be.true;
   });
 
+  it('should return an integer', () => {
+    const n = numberType({ type: 'integer' });
+    expect(Number.isInteger(n)).to.be.true;
+  });
+
   describe('should ignore min and max if using Number.MAX_VALUE in then', () => {
     it('ignoring minimum', () => {
       const n = numberType({ minimum: -Number.MAX_VALUE });


### PR DESCRIPTION
This is a quick solution for the issue I addressed in #743. Instead of making the flag hasPrecision always true for numbers, we can set it to false to fix the problem.