### PR TITLE
Allow empty arrays without defined items

### DIFF
--- a/src/lib/types/array.mjs
+++ b/src/lib/types/array.mjs
@@ -45,7 +45,9 @@ function arrayType(value, path, resolve, traverseCallback) {
 
   if (!(value.items || value.additionalItems)) {
     if (utils.hasProperties(value, 'minItems', 'maxItems', 'uniqueItems')) {
-      throw new ParseError(`missing items for ${utils.short(value)}`, path);
+      if (value.minItems !== 0 || value.maxItems !== 0) {
+        throw new ParseError(`missing items for ${utils.short(value)}`, path);
+      }
     }
     return items;
   }

--- a/tests/schema/core/types/array.json
+++ b/tests/schema/core/types/array.json
@@ -136,6 +136,17 @@
         "throws": "missing items for [\\s\\S]+ in \\/"
       },
       {
+        "description": "should validate items using all options",
+        "schema": {
+          "type": "array",
+          "minItems": 0,
+          "maxItems": 0,
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "valid": true
+      },
+      {
         "description": "should handle inferred type (when possible)",
         "schema": {
           "items": {


### PR DESCRIPTION
Schema:

```json
{
  "foo": {
    "type": "array",
    "minItems": 0,
    "maxItems": 0,
    "uniqueItems": true
  }
}
```

I would expect this schema to always generate empty arrays. Instead, I get the error below:

```
Error while resolving schema (missing items for {
  "type": "array",
  "minItems": 0,
  "maxItems": 0,
  "uniqueItems": true
} in /foo)
```

I understand why `items` is required in general, but if `minItems` and `maxItems` are both zero, no array item will ever be generated, so it should be fine for `items` to be empty. I'm using a tool that sometimes generates schemas like this, so it would be helpful if this case were handled.