### PR TITLE
ci: code refactor written in dot notation

### DIFF
--- a/src/lib/core/utils.mjs
+++ b/src/lib/core/utils.mjs
@@ -508,8 +508,8 @@ function clean(obj, schema, isArray = false) {
     } else {
       // should obtain the correct schema
       let subSchema = schema;
-      if (schema && schema['properties'] && schema['properties'][k]) {
-        subSchema = schema['properties'][k];
+      if (schema && schema.properties && schema.properties[k]) {
+        subSchema = schema.properties[k];
       }
       const value = clean(obj[k], subSchema);
 


### PR DESCRIPTION
fix: ci error, refactor code use dot notation!

/home/runner/work/json-schema-faker/json-schema-faker/src/lib/core/utils.mjs
  511:28  error  ["properties"] is better written in dot notation  dot-notation
  511:52  error  ["properties"] is better written in dot notation  dot-notation
  512:28  error  ["properties"] is better written in dot notation  dot-notation

✖ 3 problems (3 errors, 0 warnings)
  3 errors and 0 warnings potentially fixable with the `--fix` option.