### PR TITLE
chore: restore bundling from v0.5.0-rcv.46 - closes #768 #769

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-import $RefParser from '@apidevtools/json-schema-ref-parser';
-import { JSONPath } from 'jsonpath-plus';
-
-import { setDependencies } from './dist/shared.js';
-
-setDependencies({ JSONPath, $RefParser });
-
-export { default, JSONSchemaFaker } from './dist/shared.js';

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
       "types": "./index.d.ts",
       "import": "./dist/main.mjs",
       "require": "./dist/main.cjs",
-      "browser": "./dist/main.iife.js"
+      "browser": "./dist/bundle.js"
     },
-    "./esm": {
+    "./src": {
       "types": "./index.d.ts",
-      "import": "./index.js"
+      "import": "./index.mjs"
     }
   },
   "scripts": {
@@ -43,12 +43,13 @@
     "_graphviz": "madge src --dot > structure.gv",
     "mortero": "mortero -Ddist -spublic -X{_base,lib} -ecss.less",
     "watch": "npm run mortero -- --platform browser -dw",
-    "build": "NODE_ENV=production npm run mortero -- -S --no-minify",
+    "build": "NODE_ENV=production npm run mortero -- -fS --no-minify",
     "pretest": "npm run lint && npm run build -- -ymain",
-    "copy:bundle": "concat -o dist/bundle.js dist/main.iife.js",
+    "copy:vendor": "concat -o dist/vendor.js node_modules/json-schema-ref-parser/dist/ref-parser.min.js node_modules/jsonpath-plus/dist/index-browser-umd.min.cjs",
+    "copy:bundle": "concat -o dist/bundle.js dist/vendor.js dist/main.iife.js",
     "copy:wargs": "concat -o dist/wargs.cjs node_modules/wargs/dist/wargs.cjs",
     "entry:cjs": "node patch.js",
-    "postbuild": "npm run copy:bundle && npm run entry:cjs",
+    "postbuild": "npm run copy:vendor && npm run entry:cjs && npm run copy:bundle",
     "prebuild": "mkdir -p dist && npm run copy:wargs",
     "codecov": "codecov -e TRAVIS_NODE_VERSION"
   },
@@ -62,6 +63,10 @@
       "**/main.*.js",
       "**/shared.js",
       "**/app.js"
+    ],
+    "external": [
+      "json-schema-ref-parser",
+      "jsonpath-plus"
     ],
     "options": {
       "less": {
@@ -89,11 +94,15 @@
     "mocks"
   ],
   "files": [
-    "dist/*.*js",
+    "dist/*.*",
+    "index.mjs",
     "index.d.ts"
   ],
+  "dependencies": {
+    "json-schema-ref-parser": "^6.1.0",
+    "jsonpath-plus": "^7.2.0"
+  },
   "devDependencies": {
-    "@apidevtools/json-schema-ref-parser": "^10.1.0",
     "@faker-js/faker": "^7.6.0",
     "@types/json-schema": "^7.0.9",
     "ajv": "^6.12.6",
@@ -114,7 +123,6 @@
     "glob": "^7.1.2",
     "glob-parent": ">=5.1.2",
     "is-my-json-valid": "^2.19.0",
-    "jsonpath-plus": "^7.2.0",
     "less": "^4.1.1",
     "less-plugin-autoprefix": "^2.0.0",
     "live-server": "^1.2.2",

--- a/patch.js
+++ b/patch.js
@@ -5,3 +5,8 @@ cjs = cjs.replace(/module\.exports = Object\.assign/, '// $&');
 
 writeFileSync('dist/main.cjs', cjs);
 writeFileSync('dist/index.cjs', 'module.exports = require("./main.cjs").default;\n');
+
+let vendor = readFileSync('dist/vendor.js').toString();
+vendor = `if (typeof process !== 'undefined') { global.location = { href: \`\${process.cwd()}/\` }; }\n${vendor}`;
+
+writeFileSync('dist/vendor.js', vendor);

--- a/src/lib/main.mjs
+++ b/src/lib/main.mjs
@@ -1,4 +1,4 @@
-import $RefParser from '@apidevtools/json-schema-ref-parser';
+import $RefParser from 'json-schema-ref-parser';
 import { JSONPath } from 'jsonpath-plus';
 
 import { setDependencies } from './vendor.mjs';

--- a/src/main.iife.js
+++ b/src/main.iife.js
@@ -17,12 +17,12 @@
 
 const jsf = require('./shared');
 
-if (typeof window !== 'undefined') {
-  jsf.setDependencies({
-    ...window.JSONPath,
-    $RefParser: window.$RefParser,
-  });
+/* global $RefParser, JSONPath  */
+if (typeof $RefParser !== 'undefined' && typeof JSONPath !== 'undefined') {
+  jsf.setDependencies({ ...JSONPath, $RefParser });
+}
 
+if (typeof window !== 'undefined') {
   window.JSONSchemaFaker = jsf.default;
 }
 

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -1,7 +1,3 @@
-if (typeof process !== 'undefined') {
-  global.location = { href: `${process.cwd()}/` };
-}
-
 import './vendor.js';
 
 import { setDependencies } from './shared.js';

--- a/tests/integration/_deps_check.mjs
+++ b/tests/integration/_deps_check.mjs
@@ -1,0 +1,23 @@
+export async function depsCheck(jsf) {
+  const result = await jsf.resolve({ const: 42 });
+
+  jsf.option('resolveJsonPath', true);
+
+  const data = await jsf.resolve({
+    type: 'object',
+    properties: {
+      value: {
+        const: 42,
+      },
+      other: {
+        jsonPath: '$.value',
+      },
+    },
+    required: [
+      'value',
+      'other',
+    ],
+  });
+
+  return { result, data };
+}

--- a/tests/integration/commonjs.test.mjs
+++ b/tests/integration/commonjs.test.mjs
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as td from 'testdouble';
 
 import jsf, { JSONSchemaFaker } from '../../dist/main.cjs';
+import { depsCheck } from './_deps_check.mjs';
 
 describe('CommonJS', () => {
   afterEach(() => {
@@ -32,5 +33,12 @@ describe('CommonJS', () => {
     expect(JSONSchemaFaker.VERSION).not.to.be.undefined;
     expect(JSONSchemaFaker.generate).not.to.be.undefined;
     expect(JSONSchemaFaker.generate({ const: 42 })).to.eql(42);
+  });
+
+  it('should load third-party dependencies', async () => {
+    const { result, data } = await depsCheck(jsf);
+
+    expect(result).to.eql(42);
+    expect(data).to.eql({ value: 42, other: 42 });
   });
 });

--- a/tests/integration/esmodules.test.mjs
+++ b/tests/integration/esmodules.test.mjs
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import * as td from 'testdouble';
 
-import jsf, { JSONSchemaFaker } from '../../src/lib/main.mjs';
+import jsf, { JSONSchemaFaker } from '../../dist/main.mjs';
+import { depsCheck } from './_deps_check.mjs';
 
 describe('ES Module', () => {
   afterEach(() => {
@@ -32,5 +33,12 @@ describe('ES Module', () => {
     expect(JSONSchemaFaker.VERSION).not.to.be.undefined;
     expect(JSONSchemaFaker.generate).not.to.be.undefined;
     expect(JSONSchemaFaker.generate({ const: 42 })).to.eql(42);
+  });
+
+  it('should load third-party dependencies', async () => {
+    const { result, data } = await depsCheck(jsf);
+
+    expect(result).to.eql(42);
+    expect(data).to.eql({ value: 42, other: 42 });
   });
 });

--- a/tests/integration/umdwrapper.test.mjs
+++ b/tests/integration/umdwrapper.test.mjs
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import * as td from 'testdouble';
 
-import '../../dist/main.iife.js';
+import '../../dist/bundle.js';
+import { depsCheck } from './_deps_check.mjs';
 
 /* global globalThis */
 
@@ -38,6 +39,13 @@ describe('UMD Wrapper', () => {
     expect(JSONSchemaFaker.VERSION).not.to.be.undefined;
     expect(JSONSchemaFaker.generate).not.to.be.undefined;
     expect(JSONSchemaFaker.generate({ const: 42 })).to.eql(42);
+  });
+
+  it('should load third-party dependencies', async () => {
+    const { result, data } = await depsCheck(jsf);
+
+    expect(result).to.eql(42);
+    expect(data).to.eql({ value: 42, other: 42 });
   });
 });
 


### PR DESCRIPTION
Due the rush, I never confirmed our integration tests were still reliable.

Now we're just loading all dist files on these tests, we now make sure `json-schema-ref-parser` and `jsonpath-plus` still works!

Sadly, `@apidevtools/json-schema-ref-parser` is not working for us, patches are welcome. :beers: