### PR TITLE
Make sure `process.cwd` is actually a function

### DIFF
--- a/src/lib/index.mjs
+++ b/src/lib/index.mjs
@@ -114,7 +114,7 @@ jsf.resolveWithContext = (schema, refs, cwd) => {
   }
 
   // normalize basedir (browser aware)
-  cwd = cwd || (typeof process !== 'undefined' ? process.cwd() : '');
+  cwd = cwd || (typeof process !== 'undefined' && typeof process.cwd === 'function' ? process.cwd() : '');
   cwd = `${cwd.replace(/\/+$/, '')}/`;
 
   const $refs = getRefs(refs, schema);


### PR DESCRIPTION
Some environments provide `process` but not `process.cwd`