### PR TITLE
fix for anyOf wrapped in allOf with overlapping required keys

### DIFF
--- a/src/lib/core/buildResolveSchema.mjs
+++ b/src/lib/core/buildResolveSchema.mjs
@@ -120,6 +120,11 @@ const buildResolveSchema = ({
           mix.forEach(omit => {
             if (omit.required && omit !== fixed) {
               omit.required.forEach(key => {
+                // if the picked schema also includes the required key, do not delete it
+                if (fixed.required && fixed.required.includes(key)) {
+                  return;
+                }
+
                 const includesKey = copy.required && copy.required.includes(key);
                 if (copy.properties && !includesKey) {
                   delete copy.properties[key];

--- a/tests/schema/core/issues/all-of-one-of-all-of-nested-overlap-with-additional-props.json
+++ b/tests/schema/core/issues/all-of-one-of-all-of-nested-overlap-with-additional-props.json
@@ -1,0 +1,41 @@
+[
+  {
+    "description": "allOf and oneOf nested with overlapping conditions",
+    "schemas": [{
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "properties": {
+        "date_of_birth": {
+          "type": "string",
+          "minimum": 10,
+          "maximum": 10
+        },
+        "age_group": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 5
+        }
+      },
+
+      "allOf": [{
+        "anyOf": [{
+          "required": [
+            "age_group"
+          ]
+        }, {
+          "required": [
+            "age_group",
+            "date_of_birth"
+          ]
+        }]
+      }]
+    }],
+    "tests": [
+      {
+        "description": "should combine recursively",
+        "schema": "schemas.0",
+        "valid": true
+      }
+    ]
+  }
+]

--- a/tests/schema/core/issues/all-of-one-of-all-of-nested-overlap.json
+++ b/tests/schema/core/issues/all-of-one-of-all-of-nested-overlap.json
@@ -1,0 +1,42 @@
+[
+  {
+    "description": "allOf and oneOf nested with overlapping conditions",
+    "schemas": [{
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "date_of_birth": {
+          "type": "string",
+          "minimum": 10,
+          "maximum": 10
+        },
+        "age_group": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 5
+        }
+      },
+
+      "allOf": [{
+        "anyOf": [{
+          "required": [
+            "age_group"
+          ]
+        }, {
+          "required": [
+            "age_group",
+            "date_of_birth"
+          ]
+        }]
+      }]
+    }],
+    "tests": [
+      {
+        "description": "should combine recursively",
+        "schema": "schemas.0",
+        "valid": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
When the required keys for multiple anyOf overlap, the properties were begin deleted on merge when they should not have been.

This patch includes a fix for that and 2 schema unit tests that demonstrate the problem.