### PR TITLE
docs: Fix dead links in docs

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -192,7 +192,7 @@ JSONSchemaFaker.resolve(schema, refs).then((sample) => {
 
 ## Faking values
 
-`JSONSchemaFaker` has built-in generators for core-formats, [Faker.js](https://github.com/marak/Faker.js/) and [Chance.js](http://chancejs.com/) (and others) are also supported but they require setup:
+`JSONSchemaFaker` has built-in generators for core-formats, [Faker.js](https://github.com/faker-js/faker/) and [Chance.js](http://chancejs.com/) (and others) are also supported but they require setup:
 
 ```js
 JSONSchemaFaker.extend("faker", () => require("@faker-js/faker"));
@@ -207,7 +207,7 @@ JSONSchemaFaker.extend("faker", () => require("@faker-js/faker"));
 
 ([demo »](http://json-schema-faker.js.org/#gist/89659ebf28be89d3f860c3f80cbffe4b))
 
-The above schema will invoke [`faker.internet.email()`](https://github.com/Marak/faker.js/blob/1f47f09e25ad43db41ea4187c3cd3f7e113d4cb4/lib/internet.js#L32).
+The above schema will invoke [`faker.internet.email()`](https://github.com/faker-js/faker/blob/1f47f09e25ad43db41ea4187c3cd3f7e113d4cb4/lib/internet.js#L32).
 
 Note that both generators has higher precedence than **format**.
 
@@ -253,7 +253,7 @@ E.g. using `chance` to faking values while passing arguments to the generator:
 This example works for single-parameter generator function.
 
 However, if you pass multiple arguments to the generator function, just pass them wrapped in an array.
-In the example below we use the [`faker.finance.amount(min, max, dec, symbol)`](https://github.com/Marak/faker.js/blob/1f47f09e25ad43db41ea4187c3cd3f7e113d4cb4/lib/finance.js#L85)
+In the example below we use the [`faker.finance.amount(min, max, dec, symbol)`](https://github.com/faker-js/faker/blob/1f47f09e25ad43db41ea4187c3cd3f7e113d4cb4/lib/finance.js#L85)
 generator which has 4 parameters. We just wrap them with an array and it's equivalent to `faker.finance.amount(100, 10000, 2, "$")`:
 
 ```json
@@ -346,7 +346,7 @@ JSONSchemaFaker.option("alwaysFakeOptionals", true);
 
 ## Extending dependencies
 
-You may extend [Faker.js](https://github.com/Marak/faker.js):
+You may extend [Faker.js](https://github.com/faker-js/faker):
 
 ```javascript
 import { JSONSchemaFaker } from 'json-schema-faker';
@@ -373,7 +373,7 @@ const schema = {
 JSONSchemaFaker.resolve(schema).then(...);
 ```
 
-...or if you want to use [faker's _individual localization packages_](https://github.com/Marak/faker.js#individual-localization-packages), simply do the following:
+...or if you want to use [faker's _individual localization packages_](https://github.com/faker-js/faker#individual-localization-packages), simply do the following:
 
 ```js
 JSONSchemaFaker.extend("faker", () => {

--- a/public/v1/index.html
+++ b/public/v1/index.html
@@ -75,7 +75,7 @@
                         </li>
                     </ul>
                     <ul class="nav navbar-nav navbar-right">
-                        <li><a href="https://github.com/marak/Faker.js/">faker.js</a></li>
+                        <li><a href="https://github.com/faker-js/faker/">faker.js</a></li>
                         <li><a href="http://chancejs.com/">chance.js</a></li>
                         <li><a href="http://fent.github.io/randexp.js/">randexp.js</a></li>
                     </ul>

--- a/public/v1/index.html
+++ b/public/v1/index.html
@@ -9,6 +9,7 @@
         <link href="http://netdna.bootstrapcdn.com/font-awesome/3.0.2/css/font-awesome.css" rel="stylesheet">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/json-schema-faker/0.3.6/json-schema-faker.js" type="text/javascript" charset="utf-8"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.3/ace.js" type="text/javascript" charset="utf-8"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" integrity="sha512-TktJbycEG5Van9KvrSHFUcYOKBroD7QCYkEe73HAutODCw9QTFcvF6fuxioYM1h6THNudK1GjVidazj6EslK4A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
         <script src="vendor.js"></script>
         <script src="bundle.js"></script>
         <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
@@ -127,9 +128,7 @@
             </div>
         </div>
 
-        <a class="github-ribbon" href="https://github.com/json-schema-faker/json-schema-faker">
-            <img src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png">
-        </a>
+        <a class="github-fork-ribbon" href="https://github.com/json-schema-faker/json-schema-faker" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
 
         <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
I was reading through the docs, when I noticed some of the links were not working. 


I have manually previewed the urls that I have changed these to be and they seem to work.
When checking the version 1 preview, I also noticed the dead link in the image on the top right, so swapped this out for a version which seems to work.