### PR TITLE
derive narrower type definition for value types when setting options …

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ export interface JSONSchemaFakerFormat {
 }
 
 declare function JSONSchemaFakerOption(opts: JSONSchemaFakerOptions): void;
-declare function JSONSchemaFakerOption(name: keyof JSONSchemaFakerOptions, value: any): void;
+declare function JSONSchemaFakerOption<K extends keyof JSONSchemaFakerOptions>(name: K, value: JSONSchemaFakerOptions[K]): void;
 declare namespace JSONSchemaFakerOption {
   var getDefaults: () => JSONSchemaFakerOptions;
 }


### PR DESCRIPTION
…by key with JSONSchemaFakerOption

This enforces the `value` type matching the specific key's type in `JSONSchemaFakerOptions`, eg. 

```ts
// caught at compile time that ignoreProperties should be `string[] | undefined`
JSONSchemaFakerOption('ignoreProperties', 'someProp') // ...error
JSONSchemaFakerOption('ignoreProperties', ['someProp']) // ...ok
```

thank you for the awesome lib!