### PR TITLE
keep required properties in nested arrays

### DIFF
--- a/src/lib/core/utils.mjs
+++ b/src/lib/core/utils.mjs
@@ -499,7 +499,7 @@ function clean(obj, schema, isArray = false) {
 
   if (Array.isArray(obj)) {
     return obj
-      .map(value => clean(value, schema, true))
+      .map(value => clean(value, schema?.items, true))
       .filter(value => typeof value !== 'undefined');
   }
 

--- a/tests/unit/core/utils.spec.mjs
+++ b/tests/unit/core/utils.spec.mjs
@@ -523,5 +523,11 @@ describe('Utils', () => {
       const cleaned = utils.clean(a, { required: ['b'] });
       expect(cleaned).to.eql({ b: {}, c: { d: 'string value' } });
     });
+
+    it('should respect nested required keys', () => {
+      const a = [[{ b: {} }]];
+      const cleaned = utils.clean(a, { items: { items: { properties: { price: {} }, required: ['b'] } } });
+      expect(cleaned).to.eql([[{ b: {} }]]);
+    });
   });
 });


### PR DESCRIPTION
Currently there is a problem with nested array not respecting required properties. This is due to the fact that the schema is passed as-is in the clean function and nested requires are ignored. 

This PR attempts to fix it passing the items property in the recursive call to `clean`.

For example (added to tests) if we generate `[[{ b: {} }]]` from 
```json
{
  "items": {
    "items": {
      "properties": {
        "price": {}
      },
      "required": [
        "b"
      ]
    }
  }
```
should be kept as-is but instead returns `[]`

