### PR TITLE
change default array minItems to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8MXLRJ7QQXGYY)
 [![OpenCollective](https://badgen.net/opencollective/backers/json-schema-faker)](https://opencollective.com/json-schema-faker)
-[![Build status](https://github.com/json-schema-faker/json-schema-faker/workflows/ci/badge.svg)](https://github.com/json-schema-faker/json-schema-faker/actions)
+[![Build status](https://github.com/json-schema-faker/json-schema-faker/actions/workflows/testing.yml/badge.svg)](https://github.com/json-schema-faker/json-schema-faker/actions)
 [![NPM version](https://badge.fury.io/js/json-schema-faker.svg)](http://badge.fury.io/js/json-schema-faker)
 [![Coverage Status](https://codecov.io/github/json-schema-faker/json-schema-faker/coverage.svg?branch=master)](https://codecov.io/github/json-schema-faker/json-schema-faker?branch=master)
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/json-schema-faker/Lobby)
-[![Dependency Status](https://david-dm.org/json-schema-faker/json-schema-faker/status.svg)](https://david-dm.org/json-schema-faker/json-schema-faker)
-[![devDependency Status](https://david-dm.org/json-schema-faker/json-schema-faker/dev-status.svg)](https://david-dm.org/json-schema-faker/json-schema-faker#info=devDependencies)
 
-[![Inline docs](http://inch-ci.org/github/json-schema-faker/json-schema-faker.svg?branch=master)](http://inch-ci.org/github/json-schema-faker/json-schema-faker)
+[![Inline docs](https://inch-ci.org/github/json-schema-faker/json-schema-faker.svg?branch=master)](https://inch-ci.org/github/json-schema-faker/json-schema-faker)
 [![Typedoc](https://img.shields.io/badge/typedoc-provided-blue.svg)](http://json-schema-faker.github.io/json-schema-faker/)
 [![Known Vulnerabilities](https://snyk.io/test/github/json-schema-faker/json-schema-faker/badge.svg)](https://snyk.io/test/github/json-schema-faker/json-schema-faker)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-faker",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "JSON-Schema + fake data generators",
   "homepage": "http://json-schema-faker.js.org",
   "types": "index.d.ts",
@@ -12,7 +12,7 @@
   "module": "dist/main.mjs",
   "unpkg": "dist/bundle.js",
   "exports": {
-    ".": {       
+    ".": {
       "import": {
         "types": "./index.d.ts",
         "default": "./dist/main.mjs"


### PR DESCRIPTION
This PR attempts to fix broken badges.

* Removed david badges as the service has been down forever. It seems GH is working on a dependabot badge, maybe it's worth keeping an eye as that could be a good replacement 
* Changed the unexisting workflow badge with an existing one. Probably the best would be to create a different flow for pushes on master, which is the actual build, lmk if you want me to do that
*  Changed the inline docs to https, as the other badge was being blocked