### PR TITLE
Fix large minimum generation without specified maximum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-faker",
-  "version": "0.5.9",
+  "version": "0.5.7",
   "description": "JSON-Schema + fake data generators",
   "homepage": "http://json-schema-faker.js.org",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-faker",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "JSON-Schema + fake data generators",
   "homepage": "http://json-schema-faker.js.org",
   "types": "index.d.ts",
@@ -12,7 +12,7 @@
   "module": "dist/main.mjs",
   "unpkg": "dist/bundle.js",
   "exports": {
-    ".": {       
+    ".": {
       "import": {
         "types": "./index.d.ts",
         "default": "./dist/main.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-faker",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "JSON-Schema + fake data generators",
   "homepage": "http://json-schema-faker.js.org",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-faker",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "JSON-Schema + fake data generators",
   "homepage": "http://json-schema-faker.js.org",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-faker",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "JSON-Schema + fake data generators",
   "homepage": "http://json-schema-faker.js.org",
   "types": "index.d.ts",

--- a/src/lib/types/number.mjs
+++ b/src/lib/types/number.mjs
@@ -2,8 +2,16 @@ import random from '../core/random.mjs';
 import env from '../core/constants.mjs';
 
 function numberType(value) {
-  let min = (typeof value.minimum === 'undefined' || value.minimum === -Number.MAX_VALUE) ? env.MIN_INTEGER : value.minimum;
-  let max = (typeof value.maximum === 'undefined' || value.maximum === Number.MAX_VALUE) ? env.MAX_INTEGER : value.maximum;
+  let min = (typeof value.minimum === 'undefined' || value.minimum === -Number.MAX_VALUE)
+    ? env.MIN_INTEGER
+    : value.minimum;
+  let max = (typeof value.maximum === 'undefined' || value.maximum === Number.MAX_VALUE)
+    ? env.MAX_INTEGER
+    : value.maximum;
+
+  if (min > max) {
+    max = Number.MAX_SAFE_INTEGER;
+  }
 
   const multipleOf = value.multipleOf;
   const decimals = multipleOf && String(multipleOf).match(/e-(\d)|\.(\d+)$/);

--- a/tests/unit/generators/number.spec.mjs
+++ b/tests/unit/generators/number.spec.mjs
@@ -14,6 +14,13 @@ describe('Number Generator', () => {
     expect(n).not.to.eql(m);
   });
 
+  it('should return number with large minimum without specified maximum', () => {
+    const n = numberType({ minimum: 1682899200000 });
+
+    expect(n).to.be.a('number');
+    expect(n).to.be.at.least(1682899200000);
+  });
+
   it('should handle multipleOf on integers', () => {
     expect(isMultipleOf({ multipleOf: 1 })).to.be.true;
     expect(isMultipleOf({ multipleOf: 1, maximum: 1e+31 })).to.be.true;


### PR DESCRIPTION
There was an issue with timestamp integer value which is bigger than [hardcoded min value](https://github.com/json-schema-faker/json-schema-faker/blob/master/src/lib/core/constants.mjs#L8):
![Screenshot 2024-12-31 at 12 29 20](https://github.com/user-attachments/assets/55166ef8-7830-438d-b1e3-7bb09598af1e)

Please fill free to modify or notify if anything :) thanks