### PR TITLE
Publish missing index.d.cts to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
   ],
   "files": [
     "dist/*.*",
-    "index.d.ts"
+    "index.d.ts",
+    "index.d.cts"
   ],
   "dependencies": {
     "json-schema-ref-parser": "^6.1.0",


### PR DESCRIPTION
This fixes an issue where TypeScript can't find the declaration file when requiring `json-schema-faker` from a CommonJS project with `moduleResolution: 'node16'` set in `tsconfig.json`.