### PR TITLE
fix: generate required properties at maxDepth boundary

### DIFF
--- a/src/generators/object.ts
+++ b/src/generators/object.ts
@@ -102,13 +102,39 @@ export async function generateObject(
   schema: JsonSchemaObject,
   ctx: GenerateContext
 ): Promise<Record<string, unknown>> {
-  if (ctx.depth >= ctx.maxDepth) {
-    return {};
-  }
-
   // Get inferred properties if no explicit properties
   const inferredProperties = getInferredProperties(schema);
   const inferredRequired = getInferredRequired(schema, inferredProperties);
+
+  // When maxDepth is reached, still generate required properties with primitive defaults
+  // to avoid producing invalid output that violates schema constraints
+  if (ctx.depth >= ctx.maxDepth) {
+    if (inferredRequired.length === 0) {
+      return {};
+    }
+    // Generate stub values for required properties
+    const result: Record<string, unknown> = {};
+    for (const key of inferredRequired) {
+      const propSchema = inferredProperties[key];
+      if (propSchema && typeof propSchema === "object" && propSchema !== null) {
+        const schemaObj = propSchema as JsonSchemaObject;
+        // Use const/default/enum if available
+        if (schemaObj.const !== undefined) {
+          result[key] = schemaObj.const;
+        } else if (schemaObj.default !== undefined) {
+          result[key] = schemaObj.default;
+        } else if (schemaObj.enum !== undefined && schemaObj.enum.length > 0) {
+          result[key] = schemaObj.enum[0];
+        } else {
+          // Generate type-appropriate stub value
+          result[key] = generateStubValue(schemaObj.type);
+        }
+      } else {
+        result[key] = null;
+      }
+    }
+    return result;
+  }
 
   // Check for contradictory schema: additionalProperties:false but minProperties > available keys
   if (schema.additionalProperties === false) {
@@ -530,5 +556,31 @@ function pruneObjectProperties(obj: unknown, propertiesToPrune: string[]): void 
     } else {
       pruneObjectProperties(record[key], propertiesToPrune);
     }
+  }
+}
+
+/**
+ * Generate a stub value for a given JSON Schema type when maxDepth is reached.
+ * This ensures required properties still get valid (if minimal) values.
+ */
+function generateStubValue(type: string | string[] | undefined): unknown {
+  const resolvedType = Array.isArray(type) ? type[0] : type;
+  switch (resolvedType) {
+    case "string":
+      return "";
+    case "number":
+    case "integer":
+      return 0;
+    case "boolean":
+      return false;
+    case "null":
+      return null;
+    case "array":
+      return [];
+    case "object":
+      return {};
+    default:
+      // If no type specified, default to null
+      return null;
   }
 }

--- a/tests/unit/issues.test.ts
+++ b/tests/unit/issues.test.ts
@@ -49,3 +49,119 @@ describe("Issue #588 - optionalsProbability + maxItems can produce oversized arr
     }
   });
 });
+
+describe("Issue #853 - Deeply nested required properties ignored", () => {
+  test("should generate required properties even at maxDepth boundary", async () => {
+    // This schema has 5 levels of nesting (matching the default maxDepth of 5)
+    // The innermost objects should still have their required 'name' and 'code' properties
+    const schema = {
+      type: "object",
+      required: ["transactionReport"],
+      additionalProperties: false,
+      properties: {
+        transactionReport: {
+          type: "object",
+          required: ["data"],
+          additionalProperties: false,
+          properties: {
+            data: {
+              type: "array",
+              items: {
+                type: "object",
+                required: ["id", "items"],
+                additionalProperties: false,
+                properties: {
+                  id: { type: "integer", minimum: 1 },
+                  items: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      required: ["name", "code"],
+                      additionalProperties: false,
+                      properties: {
+                        code: { type: "string" },
+                        name: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = await generate(schema, { minItems: 1, seed: 1 }) as {
+      transactionReport: {
+        data: Array<{
+          id: number;
+          items: Array<{ name: string; code: string }>;
+        }>;
+      };
+    };
+
+    // Verify structure
+    expect(result.transactionReport).toBeDefined();
+    expect(result.transactionReport.data).toBeDefined();
+    expect(Array.isArray(result.transactionReport.data)).toBe(true);
+    expect(result.transactionReport.data.length).toBeGreaterThan(0);
+
+    // Verify deeply nested required properties exist
+    for (const dataItem of result.transactionReport.data) {
+      expect(dataItem.id).toBeDefined();
+      expect(dataItem.items).toBeDefined();
+      expect(Array.isArray(dataItem.items)).toBe(true);
+
+      for (const item of dataItem.items) {
+        // These are the critical assertions - previously these would be empty objects {}
+        expect(item).toHaveProperty("name");
+        expect(item).toHaveProperty("code");
+        expect(typeof item.name).toBe("string");
+        expect(typeof item.code).toBe("string");
+      }
+    }
+  });
+
+  test("should use const/default/enum values when available at maxDepth", async () => {
+    // Set maxDepth=3 to force the innermost object to be generated at maxDepth
+    // This tests that our stub value generation uses const/default/enum when available
+    // Depth counting: root(0) -> level1(1) -> level2(2) -> level3(3=maxDepth)
+    const schema = {
+      type: "object",
+      required: ["level1"],
+      properties: {
+        level1: {
+          type: "object",
+          required: ["level2"],
+          properties: {
+            level2: {
+              type: "object",
+              required: ["level3"],
+              properties: {
+                level3: {
+                  type: "object",
+                  required: ["constProp", "defaultProp", "enumProp"],
+                  properties: {
+                    constProp: { const: "constant-value" },
+                    defaultProp: { type: "string", default: "default-value" },
+                    enumProp: { enum: ["enum-val-1", "enum-val-2"] },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // At maxDepth=3, level3's properties are generated using stub values
+    const result = await generate(schema, { maxDepth: 3, seed: 1 }) as any;
+
+    const level3 = result?.level1?.level2?.level3;
+    expect(level3).toBeDefined();
+    expect(level3.constProp).toBe("constant-value");
+    expect(level3.defaultProp).toBe("default-value");
+    expect(level3.enumProp).toBe("enum-val-1"); // First enum value used as stub
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #853 - Object generation ignores `required` properties when deeply nested.

When `maxDepth` is reached during object generation, the generator was returning empty objects `{}` even when the schema specified `required` properties. This caused deeply nested schemas (5+ levels with the default maxDepth of 5) to produce invalid output that violated the schema constraints.

### Root Cause

The `generateObject` function had an early return at maxDepth:
```typescript
if (ctx.depth >= ctx.maxDepth) {
  return {};
}
```

This returned an empty object regardless of whether the schema had required properties.

### Solution

When maxDepth is reached, instead of returning an empty object:
1. Check if there are required properties
2. If yes, generate stub values for each required property:
   - Use `const` value if available
   - Use `default` value if available  
   - Use first `enum` value if available
   - Otherwise, use type-appropriate minimal values (empty string, 0, false, null, [], {})

This preserves the protection against infinite recursion while honoring required property constraints.

### Before/After

**Before (default maxDepth=5, 4 levels of nesting):**
```json
{
  "transactionReport": {
    "data": [
      {
        "id": 3,
        "items": [
          {},
          {}
        ]
      }
    ]
  }
}
```

**After:**
```json
{
  "transactionReport": {
    "data": [
      {
        "id": 3,
        "items": [
          {
            "name": "",
            "code": ""
          },
          {
            "name": "",
            "code": ""
          }
        ]
      }
    ]
  }
}
```

## Test plan

- [x] Added test case for issue #853 - deeply nested required properties
- [x] Added test case for const/default/enum values at maxDepth
- [x] All 490 existing tests pass