### PR TITLE
fix: resolve local #/... refs via JSON pointer fallback

### DIFF
--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -62,7 +62,16 @@ export async function resolveRef(
 
   if (ref.startsWith("#/")) {
     resolved = ctx.refRegistry.get(ref);
-    // If not found in registry, try refResolver (e.g. for OpenAPI-style #/components/schemas/... refs)
+    // Fallback: JSON pointer walk against the root schema.
+    // Handles any arbitrary path (#/definitions/…, #/components/schemas/…, etc.)
+    // without enumerating every possible keyword upfront.
+    if (resolved === undefined) {
+      const root = ctx.refRegistry.get("#");
+      if (root !== undefined && typeof root === "object") {
+        try { resolved = resolveFragment(root, ref.slice(1)); } catch { /* unresolvable */ }
+      }
+    }
+    // If still not found, try refResolver (e.g. for OpenAPI-style #/components/schemas/... refs)
     if (resolved === undefined && ctx.refResolver) {
       resolved = await ctx.refResolver(ref);
       if (resolved !== undefined) {

--- a/tests/unit/issues.test.ts
+++ b/tests/unit/issues.test.ts
@@ -165,3 +165,56 @@ describe("Issue #853 - Deeply nested required properties ignored", () => {
     expect(level3.enumProp).toBe("enum-val-1"); // First enum value used as stub
   });
 });
+
+describe("Issue #866 - Unresolved $ref with arbitrary JSON pointer paths", () => {
+  test("resolves $ref pointing to #/definitions/… (draft-07 style)", async () => {
+    const schema = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      definitions: {
+        Settings: {
+          type: "object",
+          required: ["currency"],
+          properties: {
+            currency: {
+              type: "object",
+              required: ["currency_code"],
+              properties: {
+                currency_code: { type: "string", default: "USD" },
+                formatted: { type: "string", pattern: "^\\$?[0-9,]+(\\.[0-9]{2})?$" },
+              },
+            },
+          },
+        },
+      },
+      type: "object",
+      required: ["settings"],
+      properties: {
+        id: { type: "string" },
+        settings: { $ref: "#/definitions/Settings" },
+        title: { type: "string" },
+      },
+    };
+
+    const result = await generate(schema as any, { seed: 1 }) as any;
+    expect(result.settings).toBeDefined();
+    expect(result.settings.currency).toBeDefined();
+    expect(typeof result.settings.currency.currency_code).toBe("string");
+  });
+
+  test("resolves $ref with any arbitrary JSON pointer path against the root schema", async () => {
+    const schema = {
+      "x-custom-types": {
+        MyString: { type: "string", minLength: 3 },
+      },
+      type: "object",
+      required: ["value"],
+      properties: {
+        value: { $ref: "#/x-custom-types/MyString" },
+      },
+    };
+
+    const result = await generate(schema as any, { seed: 1 }) as any;
+    expect(typeof result.value).toBe("string");
+    expect(result.value.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

- When a local `$ref` like `#/definitions/Foo` is not found in the pre-built registry, fall back to walking the root schema as a JSON pointer using the already-existing `resolveFragment()` function
- This handles draft-07 `definitions`, OpenAPI `components/schemas`, or any arbitrary path — no need to enumerate draft-specific keywords
- The registry fast-path (Map lookup) is unchanged; the pointer walk is only a fallback

## Why this approach

Enumerating specific keywords (`definitions`, `components`, etc.) would require updating the code for each new convention. A JSON pointer walk against the root schema handles all of them generically — the same way external refs with fragments already work.

The resolution order is now:
1. Registry lookup (fast path, pre-registered `$defs` and `$id` entries)
2. JSON pointer walk against root schema (new fallback — handles any path)
3. `refResolver` callback (user-supplied, for OpenAPI-style or remote overrides)

## Test plan

- [ ] `tests/unit/issues.test.ts` — two new tests covering the exact schema from #866 (`#/definitions/Settings`) and a generic custom path (`#/x-custom-types/MyString`)
- [ ] `tests/unit/remote-resolver.test.ts` — existing external ref tests unaffected
- [ ] `tests/integration/comprehensive-schema.test.ts` — existing `propAliases` workaround test still passes

