### PR TITLE
fix: guard bare '#/' ref from silently resolving to root schema

### DIFF
--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -65,7 +65,9 @@ export async function resolveRef(
     // Fallback: JSON pointer walk against the root schema.
     // Handles any arbitrary path (#/definitions/…, #/components/schemas/…, etc.)
     // without enumerating every possible keyword upfront.
-    if (resolved === undefined) {
+    // Guard: skip bare "#/" — resolveJsonPointer treats "/" as root, which would
+    // silently self-reference instead of throwing "Unresolved $ref".
+    if (resolved === undefined && ref.length > 2) {
       const root = ctx.refRegistry.get("#");
       if (root !== undefined && typeof root === "object") {
         try { resolved = resolveFragment(root, ref.slice(1)); } catch { /* unresolvable */ }

--- a/tests/unit/issues.test.ts
+++ b/tests/unit/issues.test.ts
@@ -217,4 +217,15 @@ describe("Issue #866 - Unresolved $ref with arbitrary JSON pointer paths", () =>
     expect(typeof result.value).toBe("string");
     expect(result.value.length).toBeGreaterThanOrEqual(3);
   });
+
+  test('bare "#/" ref throws rather than silently self-referencing', async () => {
+    const schema = {
+      type: "object",
+      required: ["value"],
+      properties: {
+        value: { $ref: "#/" },
+      },
+    };
+    await expect(generate(schema as any, { seed: 1 })).rejects.toThrow("Unresolved $ref: #/");
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #867. `resolveJsonPointer` treats `"/"` as the root schema (line 184 in `remote-resolver.ts`), so the pointer fallback introduced in #867 caused `$ref: "#/"` to silently self-reference the root instead of throwing `Unresolved $ref: #/`.

The fix is a one-character guard: only apply the pointer walk when `ref.length > 2`, which excludes the bare `#/` case while allowing any real path like `#/definitions/Foo`.

## What changed

`src/ref-resolver.ts` — added `&& ref.length > 2` to the fallback condition.

## Test plan

- [ ] New regression test: `$ref: "#/"` on a required property throws `Unresolved $ref: #/` rather than resolving silently
- [ ] Existing #866 tests (`#/definitions/…`, `#/x-custom-types/…`) still pass

```
bun test tests/unit/issues.test.ts tests/unit/remote-resolver.test.ts tests/integration/comprehensive-schema.test.ts
# 33 pass, 0 fail
```

Closes the concern raised in the review comment on #867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)