### PR TITLE
fix: Apply optional property filtering to root example and default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ await generate(schema, {
   // Value sources
   useDefaultValue: true,             // Use schema `default` values
   useExamplesValue: true,            // Use schema `examples` values
+  filterExampleDefaults: false,      // Apply optionalsProbability/alwaysFakeOptionals filtering to default/example values (default: false)
 
   // $ref recursion
   refDepthMin: 1,                    // Minimum $ref recursion depth

--- a/public/index.html
+++ b/public/index.html
@@ -1154,6 +1154,24 @@ jsf schema.json -o output.json -c 5 --seed 42</code></pre>
                                                 </div>
                                             </div>
                                         </div>
+
+                                        <div class="option-card">
+                                            <div class="relative">
+                                                <div class="flex items-start justify-between mb-4">
+                                                    <h3 class="text-lg font-semibold text-teal-400">filterExampleDefaults</h3>
+                                                    <span class="option-type">boolean</span>
+                                                </div>
+                                                <p class="text-gray-400 mb-4">Apply <code class="code-inline">optionalsProbability</code>/<code class="code-inline">alwaysFakeOptionals</code> filtering to <code class="code-inline">default</code>/<code class="code-inline">examples</code> values too, instead of always including them. <code class="code-inline">Default: false</code></p>
+                                                <div class="code-block !p-4 !text-sm">
+                                            <pre><code><span class="text-purple-400">const</span> result = <span class="text-purple-400">await</span> generate(schema, {
+    <span class="text-blue-300">useDefaultValue</span>: <span class="text-yellow-300">true</span>,
+    <span class="text-blue-300">filterExampleDefaults</span>: <span class="text-yellow-300">true</span>,
+    <span class="text-blue-300">optionalsProbability</span>: <span class="text-yellow-300">0</span>
+});
+<span class="text-gray-500">// optional properties with defaults are now omitted too</span></code></pre>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </section>
 

--- a/src/generators/object.ts
+++ b/src/generators/object.ts
@@ -402,22 +402,6 @@ export async function generateObject(
   return result;
 }
 
-function createPropertyContext(ctx: GenerateContext, key: string): GenerateContext {
-  const encodedKey = encodeJsonPointerSegment(key);
-  const outputPath = ctx.outputPath === "/" ? `/${encodedKey}` : `${ctx.outputPath}/${encodedKey}`;
-  const path = ctx.path === "/" ? `/${encodedKey}` : `${ctx.path}/${encodedKey}`;
-
-  return {
-    ...ctx,
-    path,
-    outputPath,
-  };
-}
-
-function encodeJsonPointerSegment(segment: string): string {
-  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
-}
-
 /**
  * Resolve template properties in the generated object.
  * Replaces #{propName} with the generated values.

--- a/src/generators/object.ts
+++ b/src/generators/object.ts
@@ -1,7 +1,12 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "../types.js";
 import { walk } from "../schema-walker.js";
 import { mergeSchemas } from "../merge.js";
-import { SCHEMA_KEYWORDS, isJsonSchema } from "../utils/schema-keywords.js";
+import {
+  createOptionalPropertySelector,
+  createPropertyContext,
+  getInferredProperties,
+  getInferredRequired,
+} from "../utils/optional-properties.js";
 
 /**
  * Check if a generated value matches a constraint schema (enum, const)
@@ -38,64 +43,6 @@ function isImpossibleSchema(schema: JsonSchema): boolean {
     return true;
   }
   return false;
-}
-
-/**
- * Get inferred properties from a schema object.
- * If the schema has explicit 'properties', use those.
- * Otherwise, treat non-keyword child objects as properties.
- */
-function getInferredProperties(schema: JsonSchemaObject): Record<string, JsonSchema> {
-  // If schema has explicit properties, use those
-  if (schema.properties) {
-    return schema.properties;
-  }
-  
-  // If schema has type:object but no properties, check for inferred properties
-  if (schema.type === 'object' || schema.type === undefined) {
-    const inferred: Record<string, JsonSchema> = {};
-    let hasInferredProperties = false;
-    
-    for (const [key, value] of Object.entries(schema)) {
-      // Skip schema keywords
-      if (SCHEMA_KEYWORDS.has(key)) {
-        continue;
-      }
-      
-      // If it looks like a schema, use it as-is
-      if (isJsonSchema(value)) {
-        inferred[key] = value as JsonSchema;
-        hasInferredProperties = true;
-      } else {
-        // Treat as a const/literal value - wrap in a const schema
-        inferred[key] = { const: value };
-        hasInferredProperties = true;
-      }
-    }
-    
-    if (hasInferredProperties) {
-      return inferred;
-    }
-  }
-  
-  return {};
-}
-
-/**
- * Get required properties from a schema object.
- * If no explicit 'required' and we have inferred properties, all are required.
- */
-function getInferredRequired(schema: JsonSchemaObject, inferredProperties: Record<string, JsonSchema>): string[] {
-  if (schema.required) {
-    return schema.required;
-  }
-  
-  // If we have inferred properties and no explicit type/properties, require all
-  if (schema.properties === undefined && Object.keys(inferredProperties).length > 0) {
-    return Object.keys(inferredProperties);
-  }
-  
-  return [];
 }
 
 export async function generateObject(
@@ -165,28 +112,9 @@ export async function generateObject(
   const definedKeys = new Set<string>();
 
   const required = new Set(inferredRequired);
-  const alwaysFakeOptionals = ctx.alwaysFakeOptionals ?? false;
   const fillProperties = ctx.fillProperties ?? true;
-  const useFixedProbabilities = ctx.fixedProbabilities ?? false;
-  const optionalsProbability = ctx.optionalsProbability ?? 0.5;
-
-  // Get optional property keys
-  const optionalKeys = Object.keys(inferredProperties).filter(key => !required.has(key));
-  
-  // When using fixed probabilities, deterministically calculate how many properties to include
-  let propertiesToInclude: Set<string> | undefined;
-  if (useFixedProbabilities && !alwaysFakeOptionals && optionalKeys.length > 0) {
-    const targetCount = Math.round(optionalKeys.length * optionalsProbability);
-    // Deterministically select the first N properties based on the sorted keys
-    propertiesToInclude = new Set(optionalKeys.slice(0, targetCount));
-  }
-
-  // Determine if we should generate optional properties
-  const shouldGenerateOptional = (key: string) => {
-    if (alwaysFakeOptionals) return true;
-    if (propertiesToInclude) return propertiesToInclude.has(key);
-    return ctx.random.bool(optionalsProbability);
-  };
+  const optionalKeys = Object.keys(inferredProperties).filter((key) => !required.has(key));
+  const shouldGenerateOptional = createOptionalPropertySelector(ctx, optionalKeys);
 
   // Generate required properties first
   if (Object.keys(inferredProperties).length > 0) {
@@ -474,20 +402,6 @@ export async function generateObject(
   return result;
 }
 
-function createPropertyContext(ctx: GenerateContext, key: string): GenerateContext {
-  const encodedKey = encodeJsonPointerSegment(key);
-  const outputPath = ctx.outputPath === "/" ? `/${encodedKey}` : `${ctx.outputPath}/${encodedKey}`;
-
-  return {
-    ...ctx,
-    path: `${ctx.path}/${key}`,
-    outputPath,
-  };
-}
-
-function encodeJsonPointerSegment(segment: string): string {
-  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
-}
 
 /**
  * Resolve template properties in the generated object.

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export async function generate(schema: JsonSchema, options?: GenerateOptions): P
     refDepthMin,
     refDepthMax,
     useExamplesValue: normalizedOptions.useExamplesValue,
+    filterExampleDefaults: normalizedOptions.filterExampleDefaults ?? false,
     pruneProperties: normalizedOptions.pruneProperties,
     failOnInvalidTypes: normalizedOptions.failOnInvalidTypes,
     defaultInvalidTypeProduct: normalizedOptions.defaultInvalidTypeProduct,

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -11,6 +11,7 @@ import { generateComposition } from "./generators/composition.js";
 import { resolveRef } from "./ref-resolver.js";
 import { SCHEMA_KEYWORDS } from "./utils/schema-keywords.js";
 import { pad2 } from "./utils/helpers.js";
+import { filterExampleDefaultValue } from "./utils/optional-properties.js";
 import { generateFromExtensions } from "./extensions.js";
 
 const ALL_TYPES = ["string", "number", "integer", "boolean", "null", "object", "array"] as const;
@@ -280,7 +281,7 @@ export async function walk(schema: JsonSchema, ctx: GenerateContext): Promise<un
 
   // default value (when useDefaultValue option is enabled)
   if (ctx.useDefaultValue && schema.default !== undefined) {
-    return applyOutputTransform(schema.default, schema, ctx);
+    return applyOutputTransform(filterExampleDefaultValue(schema.default, schema, ctx), schema, ctx);
   }
 
   // enum
@@ -291,10 +292,11 @@ export async function walk(schema: JsonSchema, ctx: GenerateContext): Promise<un
   // examples value (when useExamplesValue option is enabled)
   if (ctx.useExamplesValue) {
     if (Array.isArray(schema.examples) && schema.examples.length > 0) {
-      return applyOutputTransform(ctx.random.pick(schema.examples), schema, ctx);
+      const picked = ctx.random.pick(schema.examples);
+      return applyOutputTransform(filterExampleDefaultValue(picked, schema, ctx), schema, ctx);
     }
     if (schema.example !== undefined) {
-      return applyOutputTransform(schema.example, schema, ctx);
+      return applyOutputTransform(filterExampleDefaultValue(schema.example, schema, ctx), schema, ctx);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,8 @@ export interface GenerateOptions {
   refDepth?: number;
   /** Use examples array values when generating */
   useExamplesValue?: boolean;
+  /** Apply optional-property filtering (optionalsProbability/alwaysFakeOptionals) to example/default values. Default: false */
+  filterExampleDefaults?: boolean;
   /** Remove specified properties from generated objects */
   pruneProperties?: string[];
   /** Handle invalid types by returning a default product instead of throwing */
@@ -197,6 +199,8 @@ export interface GenerateContext {
   refDepthMax?: number;
   /** Use examples array values when generating */
   useExamplesValue?: boolean;
+  /** Apply optional-property filtering (optionalsProbability/alwaysFakeOptionals) to example/default values. Default: false */
+  filterExampleDefaults?: boolean;
   /** Remove specified properties from generated objects */
   pruneProperties?: string[];
   /** Handle invalid types by returning a default product instead of throwing */

--- a/src/utils/optional-properties.ts
+++ b/src/utils/optional-properties.ts
@@ -1,0 +1,200 @@
+import type { JsonSchema, JsonSchemaObject, GenerateContext } from "../types.js";
+import { SCHEMA_KEYWORDS, isJsonSchema } from "./schema-keywords.js";
+
+export function getInferredProperties(schema: JsonSchemaObject): Record<string, JsonSchema> {
+  if (schema.properties) {
+    return schema.properties;
+  }
+
+  if (schema.type === "object" || schema.type === undefined) {
+    const inferred: Record<string, JsonSchema> = {};
+    let hasInferredProperties = false;
+
+    for (const [key, value] of Object.entries(schema)) {
+      if (SCHEMA_KEYWORDS.has(key)) {
+        continue;
+      }
+
+      if (isJsonSchema(value)) {
+        inferred[key] = value as JsonSchema;
+        hasInferredProperties = true;
+      } else {
+        inferred[key] = { const: value };
+        hasInferredProperties = true;
+      }
+    }
+
+    if (hasInferredProperties) {
+      return inferred;
+    }
+  }
+
+  return {};
+}
+
+export function getInferredRequired(
+  schema: JsonSchemaObject,
+  inferredProperties: Record<string, JsonSchema>
+): string[] {
+  if (schema.required) {
+    return schema.required;
+  }
+
+  if (schema.properties === undefined && Object.keys(inferredProperties).length > 0) {
+    return Object.keys(inferredProperties);
+  }
+
+  return [];
+}
+
+export function createOptionalPropertySelector(
+  ctx: GenerateContext,
+  optionalKeys: readonly string[]
+): (key: string) => boolean {
+  const alwaysFakeOptionals = ctx.alwaysFakeOptionals ?? false;
+  const useFixedProbabilities = ctx.fixedProbabilities ?? false;
+  const optionalsProbability = ctx.optionalsProbability ?? 0.5;
+
+  let propertiesToInclude: Set<string> | undefined;
+  if (useFixedProbabilities && !alwaysFakeOptionals && optionalKeys.length > 0) {
+    const targetCount = Math.round(optionalKeys.length * optionalsProbability);
+    propertiesToInclude = new Set(optionalKeys.slice(0, targetCount));
+  }
+
+  return (key: string) => {
+    if (alwaysFakeOptionals) return true;
+    if (propertiesToInclude) return propertiesToInclude.has(key);
+    return ctx.random.bool(optionalsProbability);
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function encodeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+export function createPropertyContext(ctx: GenerateContext, key: string): GenerateContext {
+  const encodedKey = encodeJsonPointerSegment(key);
+  const outputPath = ctx.outputPath === "/" ? `/${encodedKey}` : `${ctx.outputPath}/${encodedKey}`;
+
+  return {
+    ...ctx,
+    path: `${ctx.path}/${key}`,
+    outputPath,
+  };
+}
+
+// Like getInferredProperties but also inspects allOf branches so that composition
+// schemas are not silently passed through unfiltered.
+function getFilterableProperties(schema: JsonSchemaObject): Record<string, JsonSchema> {
+  const direct = getInferredProperties(schema);
+  if (Object.keys(direct).length > 0) {
+    return direct;
+  }
+
+  if (Array.isArray(schema.allOf)) {
+    const merged: Record<string, JsonSchema> = {};
+    for (const sub of schema.allOf) {
+      if (typeof sub !== "object" || sub === null) continue;
+      const subProps = getInferredProperties(sub as JsonSchemaObject);
+      Object.assign(merged, subProps);
+    }
+    return merged;
+  }
+
+  return {};
+}
+
+// Like getInferredRequired but also collects required arrays from allOf branches.
+function getFilterableRequired(
+  schema: JsonSchemaObject,
+  filterProperties: Record<string, JsonSchema>
+): string[] {
+  const direct = getInferredRequired(schema, filterProperties);
+  if (direct.length > 0) {
+    return direct;
+  }
+
+  if (Array.isArray(schema.allOf)) {
+    const required: string[] = [];
+    for (const sub of schema.allOf) {
+      if (typeof sub !== "object" || sub === null) continue;
+      const sub2 = sub as JsonSchemaObject;
+      if (Array.isArray(sub2.required)) {
+        required.push(...sub2.required);
+      }
+    }
+    if (required.length > 0) {
+      return [...new Set(required)];
+    }
+  }
+
+  return [];
+}
+
+function filterNestedValue(value: unknown, propSchema: JsonSchema, propCtx: GenerateContext): unknown {
+  if (!isPlainObject(value) || typeof propSchema !== "object" || propSchema === null) {
+    return value;
+  }
+  return filterExampleObject(value, propSchema as JsonSchemaObject, propCtx);
+}
+
+export function filterExampleObject(
+  value: Record<string, unknown>,
+  schema: JsonSchemaObject,
+  ctx: GenerateContext
+): Record<string, unknown> {
+  if (ctx.alwaysFakeOptionals === true) {
+    return value;
+  }
+
+  const inferredProperties = getFilterableProperties(schema);
+  if (Object.keys(inferredProperties).length === 0) {
+    return value;
+  }
+
+  const inferredRequired = getFilterableRequired(schema, inferredProperties);
+  const required = new Set(inferredRequired);
+
+  // Include extra keys present in the example value (e.g. additionalProperties keys) so
+  // they are subject to the same optional filter rather than being silently dropped.
+  const allKnownKeys = new Set([...Object.keys(inferredProperties), ...Object.keys(value)]);
+  const optionalKeys = [...allKnownKeys].filter((key) => !required.has(key));
+  const shouldIncludeOptional = createOptionalPropertySelector(ctx, optionalKeys);
+
+  const childCtxPath = ctx.path === "/" ? "/properties" : `${ctx.path}/properties`;
+  const childCtx: GenerateContext = { ...ctx, depth: ctx.depth + 1, path: childCtxPath };
+
+  const result: Record<string, unknown> = {};
+
+  for (const key of allKnownKeys) {
+    if (!(key in value)) {
+      continue; // Key defined by schema but absent from example — skip without touching RNG
+    }
+
+    const propCtx = createPropertyContext(childCtx, key);
+    const propSchema = inferredProperties[key] ?? true;
+
+    if (required.has(key)) {
+      result[key] = filterNestedValue(value[key], propSchema, propCtx);
+    } else if (shouldIncludeOptional(key)) {
+      result[key] = filterNestedValue(value[key], propSchema, propCtx);
+    }
+  }
+
+  return result;
+}
+
+export function filterExampleDefaultValue(
+  value: unknown,
+  schema: JsonSchemaObject,
+  ctx: GenerateContext
+): unknown {
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  return filterExampleObject(value, schema, ctx);
+}

--- a/src/utils/optional-properties.ts
+++ b/src/utils/optional-properties.ts
@@ -159,11 +159,13 @@ export function filterExampleObject(
   const inferredRequired = getFilterableRequired(schema, inferredProperties);
   const required = new Set(inferredRequired);
 
-  // Include extra keys present in the example value (e.g. additionalProperties keys) so
-  // they are subject to the same optional filter rather than being silently dropped.
-  const allKnownKeys = new Set([...Object.keys(inferredProperties), ...Object.keys(value)]);
-  const optionalKeys = [...allKnownKeys].filter((key) => !required.has(key));
+  const declaredKeys = new Set(Object.keys(inferredProperties));
+  const optionalKeys = [...declaredKeys].filter((key) => !required.has(key));
   const shouldIncludeOptional = createOptionalPropertySelector(ctx, optionalKeys);
+
+  // Keys present in the value but not declared in the schema (e.g. additionalProperties
+  // passthrough data) are always kept — they aren't "optional properties" to filter.
+  const allKnownKeys = new Set([...declaredKeys, ...Object.keys(value)]);
 
   const childCtxPath = ctx.path === "/" ? "/properties" : `${ctx.path}/properties`;
   const childCtx: GenerateContext = { ...ctx, depth: ctx.depth + 1, path: childCtxPath };
@@ -177,10 +179,9 @@ export function filterExampleObject(
 
     const propCtx = createPropertyContext(childCtx, key);
     const propSchema = inferredProperties[key] ?? true;
+    const isDeclaredOptional = declaredKeys.has(key) && !required.has(key);
 
-    if (required.has(key)) {
-      result[key] = filterNestedValue(value[key], propSchema, propCtx);
-    } else if (shouldIncludeOptional(key)) {
+    if (!isDeclaredOptional || shouldIncludeOptional(key)) {
       result[key] = filterNestedValue(value[key], propSchema, propCtx);
     }
   }
@@ -193,7 +194,7 @@ export function filterExampleDefaultValue(
   schema: JsonSchemaObject,
   ctx: GenerateContext
 ): unknown {
-  if (!isPlainObject(value)) {
+  if (!ctx.filterExampleDefaults || !isPlainObject(value)) {
     return value;
   }
   return filterExampleObject(value, schema, ctx);

--- a/src/utils/optional-properties.ts
+++ b/src/utils/optional-properties.ts
@@ -79,10 +79,11 @@ export function encodeJsonPointerSegment(segment: string): string {
 export function createPropertyContext(ctx: GenerateContext, key: string): GenerateContext {
   const encodedKey = encodeJsonPointerSegment(key);
   const outputPath = ctx.outputPath === "/" ? `/${encodedKey}` : `${ctx.outputPath}/${encodedKey}`;
+  const path = ctx.path === "/" ? `/${encodedKey}` : `${ctx.path}/${encodedKey}`;
 
   return {
     ...ctx,
-    path: `${ctx.path}/${key}`,
+    path,
     outputPath,
   };
 }

--- a/tests/unit/example-optionals.test.ts
+++ b/tests/unit/example-optionals.test.ts
@@ -1,0 +1,176 @@
+import { describe, test, expect } from "bun:test";
+import { generate } from "../../src/index.js";
+
+const objectExampleSchema = {
+  type: "object" as const,
+  required: ["id"],
+  properties: {
+    id: { type: "string" as const },
+    name: { type: "string" as const },
+    email: { type: "string" as const },
+  },
+  example: {
+    id: "req-1",
+    name: "optional-name",
+    email: "opt@example.com",
+  },
+};
+
+const objectDefaultSchema = {
+  type: "object" as const,
+  required: ["id"],
+  properties: {
+    id: { type: "string" as const },
+    name: { type: "string" as const },
+  },
+  default: {
+    id: "req-1",
+    name: "optional-name",
+  },
+};
+
+const nestedExampleSchema = {
+  type: "object" as const,
+  required: ["user"],
+  properties: {
+    user: {
+      type: "object" as const,
+      required: ["name"],
+      properties: {
+        name: { type: "string" as const },
+        email: { type: "string" as const },
+      },
+    },
+    optionalMeta: { type: "string" as const },
+  },
+  example: {
+    user: { name: "a", email: "b" },
+    optionalMeta: "x",
+  },
+};
+
+const fixedProbabilitiesSchema = {
+  type: "object" as const,
+  properties: {
+    optionalProperty1: { type: "number" as const },
+    optionalProperty2: { type: "number" as const },
+    optionalProperty3: { type: "number" as const },
+    optionalProperty4: { type: "number" as const },
+    optionalProperty5: { type: "number" as const },
+  },
+  example: {
+    optionalProperty1: 1,
+    optionalProperty2: 2,
+    optionalProperty3: 3,
+    optionalProperty4: 4,
+    optionalProperty5: 5,
+  },
+};
+
+const examplesArraySchema = {
+  type: "object" as const,
+  required: ["id"],
+  properties: {
+    id: { type: "string" as const },
+    name: { type: "string" as const },
+  },
+  examples: [
+    { id: "req-1", name: "optional-name" },
+    { id: "req-2", name: "other-name" },
+  ],
+};
+
+describe("example/default optional filtering", () => {
+  test("filters root example with optionalsProbability 0", async () => {
+    const value = await generate(objectExampleSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      optionalsProbability: 0,
+    });
+
+    expect(value).toEqual({ id: "req-1" });
+  });
+
+  test("filters root example with requiredOnly", async () => {
+    const value = await generate(objectExampleSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      requiredOnly: true,
+    } as Parameters<typeof generate>[1]);
+
+    expect(value).toEqual({ id: "req-1" });
+  });
+
+  test("alwaysFakeOptionals overrides filtering for root example", async () => {
+    const value = await generate(objectExampleSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      optionalsProbability: 0,
+      alwaysFakeOptionals: true,
+    });
+
+    expect(value).toEqual(objectExampleSchema.example);
+  });
+
+  test("filters root default object with optionalsProbability 0", async () => {
+    const value = await generate(objectDefaultSchema, {
+      seed: 1,
+      useDefaultValue: true,
+      optionalsProbability: 0,
+    });
+
+    expect(value).toEqual({ id: "req-1" });
+  });
+
+  test("filters nested optional fields inside root example", async () => {
+    const value = await generate(nestedExampleSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      optionalsProbability: 0,
+    });
+
+    expect(value).toEqual({ user: { name: "a" } });
+  });
+
+  test("uses fixedProbabilities to pick a deterministic optional subset from example", async () => {
+    const value = await generate(fixedProbabilitiesSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      fixedProbabilities: true,
+      optionalsProbability: 0.5,
+    });
+
+    expect(value).toEqual({
+      optionalProperty1: 1,
+      optionalProperty2: 2,
+      optionalProperty3: 3,
+    });
+  });
+
+  test("filters object picked from root examples array", async () => {
+    const value = await generate(examplesArraySchema, {
+      seed: 1,
+      useExamplesValue: true,
+      optionalsProbability: 0,
+    }) as Record<string, unknown>;
+
+    expect(Object.keys(value).sort()).toEqual(["id"]);
+    expect(["req-1", "req-2"]).toContain(value.id as string);
+  });
+
+  test("does not filter non-object example values", async () => {
+    const value = await generate(
+      {
+        type: "string" as const,
+        example: "hello",
+      },
+      {
+        seed: 1,
+        useExamplesValue: true,
+        optionalsProbability: 0,
+      }
+    );
+
+    expect(value).toBe("hello");
+  });
+});

--- a/tests/unit/example-optionals.test.ts
+++ b/tests/unit/example-optionals.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { generate } from "../../src/index.js";
+import type { JsonSchema } from "../../src/types.js";
 
 const objectExampleSchema = {
   type: "object" as const,
@@ -67,6 +68,43 @@ const fixedProbabilitiesSchema = {
   },
 };
 
+const nestedAllOfExampleSchema = {
+  type: "object" as const,
+  required: ["id", "meta"],
+  properties: {
+    id: { type: "string" as const },
+    meta: {
+      properties: {},
+      allOf: [
+        { properties: { a: { type: "string" as const } }, required: ["a"] } as JsonSchema,
+        { properties: { b: { type: "string" as const } }, required: ["a"] } as JsonSchema,
+      ],
+    },
+  },
+  example: {
+    id: "req-1",
+    meta: { a: "req-a", b: "opt-b" },
+  },
+};
+
+const noDeclaredPropertiesSchema = {
+  type: "object" as const,
+  example: { a: 1, b: 2 },
+};
+
+const nestedSchemalessExampleSchema = {
+  type: "object" as const,
+  required: ["id", "meta"],
+  properties: {
+    id: { type: "string" as const },
+    meta: {},
+  },
+  example: {
+    id: "req-1",
+    meta: { x: 1, y: 2 },
+  },
+};
+
 const examplesArraySchema = {
   type: "object" as const,
   required: ["id"],
@@ -81,10 +119,31 @@ const examplesArraySchema = {
 };
 
 describe("example/default optional filtering", () => {
+  test("returns example verbatim when filterExampleDefaults is not set", async () => {
+    const value = await generate(objectExampleSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      optionalsProbability: 0,
+    });
+
+    expect(value).toEqual(objectExampleSchema.example);
+  });
+
+  test("returns default verbatim when filterExampleDefaults is not set", async () => {
+    const value = await generate(objectDefaultSchema, {
+      seed: 1,
+      useDefaultValue: true,
+      optionalsProbability: 0,
+    });
+
+    expect(value).toEqual(objectDefaultSchema.default);
+  });
+
   test("filters root example with optionalsProbability 0", async () => {
     const value = await generate(objectExampleSchema, {
       seed: 1,
       useExamplesValue: true,
+      filterExampleDefaults: true,
       optionalsProbability: 0,
     });
 
@@ -95,6 +154,7 @@ describe("example/default optional filtering", () => {
     const value = await generate(objectExampleSchema, {
       seed: 1,
       useExamplesValue: true,
+      filterExampleDefaults: true,
       requiredOnly: true,
     } as Parameters<typeof generate>[1]);
 
@@ -105,6 +165,7 @@ describe("example/default optional filtering", () => {
     const value = await generate(objectExampleSchema, {
       seed: 1,
       useExamplesValue: true,
+      filterExampleDefaults: true,
       optionalsProbability: 0,
       alwaysFakeOptionals: true,
     });
@@ -116,6 +177,7 @@ describe("example/default optional filtering", () => {
     const value = await generate(objectDefaultSchema, {
       seed: 1,
       useDefaultValue: true,
+      filterExampleDefaults: true,
       optionalsProbability: 0,
     });
 
@@ -126,6 +188,7 @@ describe("example/default optional filtering", () => {
     const value = await generate(nestedExampleSchema, {
       seed: 1,
       useExamplesValue: true,
+      filterExampleDefaults: true,
       optionalsProbability: 0,
     });
 
@@ -136,6 +199,7 @@ describe("example/default optional filtering", () => {
     const value = await generate(fixedProbabilitiesSchema, {
       seed: 1,
       useExamplesValue: true,
+      filterExampleDefaults: true,
       fixedProbabilities: true,
       optionalsProbability: 0.5,
     });
@@ -151,11 +215,65 @@ describe("example/default optional filtering", () => {
     const value = await generate(examplesArraySchema, {
       seed: 1,
       useExamplesValue: true,
+      filterExampleDefaults: true,
       optionalsProbability: 0,
     }) as Record<string, unknown>;
 
     expect(Object.keys(value).sort()).toEqual(["id"]);
     expect(["req-1", "req-2"]).toContain(value.id as string);
+  });
+
+  test("keeps additionalProperties keys not declared in schema.properties", async () => {
+    const value = await generate(
+      {
+        type: "object" as const,
+        required: ["id"],
+        properties: { id: { type: "string" as const } },
+        additionalProperties: true,
+        example: { id: "req-1", extraField: "should-stay" },
+      },
+      {
+        seed: 1,
+        useExamplesValue: true,
+        filterExampleDefaults: true,
+        optionalsProbability: 0,
+      }
+    );
+
+    expect(value).toEqual({ id: "req-1", extraField: "should-stay" });
+  });
+
+  test("merges properties and required from allOf branches on a nested schema", async () => {
+    const value = await generate(nestedAllOfExampleSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      filterExampleDefaults: true,
+      optionalsProbability: 0,
+    });
+
+    expect(value).toEqual({ id: "req-1", meta: { a: "req-a" } });
+  });
+
+  test("keeps example verbatim when schema declares no filterable properties", async () => {
+    const value = await generate(noDeclaredPropertiesSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      filterExampleDefaults: true,
+      optionalsProbability: 0,
+    });
+
+    expect(value).toEqual({ a: 1, b: 2 });
+  });
+
+  test("keeps a nested value verbatim when its schema declares no filterable properties", async () => {
+    const value = await generate(nestedSchemalessExampleSchema, {
+      seed: 1,
+      useExamplesValue: true,
+      filterExampleDefaults: true,
+      optionalsProbability: 0,
+    });
+
+    expect(value).toEqual({ id: "req-1", meta: { x: 1, y: 2 } });
   });
 
   test("does not filter non-object example values", async () => {


### PR DESCRIPTION
## Bug

When a schema uses `example`, `examples`, or `default` values that contain object properties, those values were returned as-is — bypassing the optional property filtering controlled by `optionalsProbability` and `alwaysFakeOptionals`. This meant that properties marked as optional in the schema were always included in the output when the generator fell back to an example or default value, regardless of the configured options.

## Rationale

The `example`/`default` paths in the schema walker short-circuit normal generation, so the filtering that applies to generated objects never ran for these values. The fix should be consistent: if a user configures `optionalsProbability: 0`, optional properties should be excluded regardless of whether the value came from generation or from an example/default.

## Approach

- Extracted the optional-property filtering logic from the object generator into a shared utility, and applied it to `example`, `examples[n]`, and `default` values behind a new opt-in `filterExampleDefaults` option (default `false`), since enabling it unconditionally would change output for existing users
- Filtering recurses into nested object properties (including those merged in from `allOf` branches), while leaving non-object values and keys not declared in the schema (e.g. `additionalProperties` data) untouched
- Documented the new option in the README and `public/index.html`
