### PR TITLE
fix: batch fixes for #869, #871, #872, #873, #874

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,16 @@ define("uuid", function(_value, _schema, ctx) {
 
   return "fallback-id";
 });
+
+define("wrapped", async function(value, _schema, ctx) {
+  return {
+    value: await ctx.proceed(value),
+  };
+});
 ```
 
 For nested properties, `ctx.path` is the schema traversal path and `ctx.outputPath` is the final generated-output JSON pointer.
+Use `ctx.proceed(subschema, overrides?)` when an extension needs to recurse through the normal generator for a nested schema.
 
 ### Composition behavior
 

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -5,7 +5,7 @@ export type ExtensionCallback = (
   value: unknown,
   schema: JsonSchemaObject,
   ctx: GenerateContext
-) => unknown;
+) => unknown | Promise<unknown>;
 
 export interface ExtensionContext {
   [key: string]: unknown;
@@ -46,10 +46,10 @@ class ExtensionRegistry {
     return this.extensions.keys();
   }
 
-  generate(
+  async generate(
     schema: JsonSchemaObject,
     ctx: GenerateContext
-  ): unknown {
+  ): Promise<unknown> {
     const keys = Object.keys(schema);
 
     for (let i = keys.length - 1; i >= 0; i--) {
@@ -59,7 +59,7 @@ class ExtensionRegistry {
 
       if (entry) {
         const value = schema[key];
-        const result = entry.callback.call(entry.context, value, schema, ctx);
+        const result = await entry.callback.call(entry.context, value, schema, ctx);
 
         if (result !== undefined) {
           return result;
@@ -95,7 +95,7 @@ export function resetExtension(name?: string): void {
 export function generateFromExtensions(
   schema: JsonSchemaObject,
   ctx: GenerateContext
-): unknown {
+): Promise<unknown> {
   return globalExtensions.generate(schema, ctx);
 }
 

--- a/src/generators/array.ts
+++ b/src/generators/array.ts
@@ -140,7 +140,6 @@ export async function generateArray(
   // 1. items is explicitly defined (not undefined), OR
   // 2. prefixItems is NOT present (use items as fallback for non-tuple arrays)
   // 3. additionalItems is defined (not false) when prefixItems is present
-  const hasExplicitItems = schema.items !== undefined;
   const hasPrefixItems = schema.prefixItems !== undefined;
   const hasAdditionalItems = schema.additionalItems !== undefined;
   

--- a/src/generators/integer.ts
+++ b/src/generators/integer.ts
@@ -25,8 +25,13 @@ export function generateInteger(
 }
 
 function getAutoIncrementCounterKey(path: string): string {
-  return path
-    .split("/")
-    .filter((segment) => segment !== "" && !/^\d+$/.test(segment))
+  const arrayItemParents = new Set(["items", "prefixItems", "contains", "additionalItems"]);
+  const segments = path.split("/").filter((segment) => segment !== "");
+
+  return segments
+    .filter((segment, index) => {
+      const previous = segments[index - 1];
+      return !(/^\d+$/.test(segment) && previous !== undefined && arrayItemParents.has(previous));
+    })
     .join("/");
 }

--- a/src/generators/object.ts
+++ b/src/generators/object.ts
@@ -477,10 +477,11 @@ export async function generateObject(
 function createPropertyContext(ctx: GenerateContext, key: string): GenerateContext {
   const encodedKey = encodeJsonPointerSegment(key);
   const outputPath = ctx.outputPath === "/" ? `/${encodedKey}` : `${ctx.outputPath}/${encodedKey}`;
+  const path = ctx.path === "/" ? `/${encodedKey}` : `${ctx.path}/${encodedKey}`;
 
   return {
     ...ctx,
-    path: `${ctx.path}/${key}`,
+    path,
     outputPath,
   };
 }

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -257,9 +257,13 @@ export async function walk(schema: JsonSchema, ctx: GenerateContext): Promise<un
   }
 
   // Custom keyword extensions (jsf.define)
-  const customExtResult = generateFromExtensions(schema, ctx);
+  const extCtx: GenerateContext = {
+    ...ctx,
+    proceed: (subSchema, overrides) => walk(subSchema, { ...ctx, ...overrides }),
+  };
+  const customExtResult = await generateFromExtensions(schema, extCtx);
   if (customExtResult !== undefined) {
-    return applyOutputTransform(customExtResult, schema, ctx);
+    return applyOutputTransform(customExtResult, schema, extCtx);
   }
 
   // $ref resolution

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -208,6 +208,15 @@ export async function walk(schema: JsonSchema, ctx: GenerateContext): Promise<un
     throw new Error(`Cannot generate value for 'false' schema at ${ctx.path}`);
   }
 
+  if (typeof schema === "object" && schema !== null && schema.$defs) {
+    for (const [name, def] of Object.entries(schema.$defs)) {
+      const key = `#/$defs/${name}`;
+      if (!ctx.refRegistry.has(key)) {
+        ctx.refRegistry.set(key, def);
+      }
+    }
+  }
+
   // Apply propAliases: remap custom schema keys to known ones before processing
   if (ctx.propAliases && typeof schema === 'object' && schema !== null) {
     const schemaObj = schema as JsonSchemaObject;

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,8 @@ export interface GenerateContext {
   propAliases?: Record<string, string>;
   /** Transform generated output values using the final output-tree JSON pointer path */
   outputTransform?: (value: unknown, schema: JsonSchema, path: string) => unknown | Promise<unknown>;
+  /** Generate a value from a subschema using the current generation context */
+  proceed?: (schema: JsonSchema, overrides?: Partial<GenerateContext>) => Promise<unknown>;
 }
 
 export interface Random {

--- a/src/utils/jsonpath.ts
+++ b/src/utils/jsonpath.ts
@@ -3,6 +3,7 @@
  * 
  * Supports:
  * - $.foo.bar - dot notation for property access
+ * - $["foo"] / $['foo'] - bracket-quoted property access
  * - $..foo - recursive descent
  * - [*] - array wildcard
  * - [n] - array index
@@ -12,14 +13,11 @@ export function evaluateJsonPath(path: string, data: unknown): unknown[] {
     throw new Error(`Invalid JSONPath: ${path} (must start with $)`);
   }
 
-  // Remove the leading $
-  const segments = path.slice(1).split(/\.|\[(\d+|\*)\]/).filter(Boolean);
+  const segments = parseJsonPath(path);
   
   let results: unknown[] = [data];
   
   for (const segment of segments) {
-    if (segment === "") continue;
-    
     const newResults: unknown[] = [];
     
     for (const item of results) {
@@ -38,7 +36,6 @@ export function evaluateJsonPath(path: string, data: unknown): unknown[] {
         }
       } else if (segment === "") {
         // Recursive descent operator (..)
-        // This is handled specially - we need to collect all nested values
         collectDescendants(item, newResults);
       } else {
         // Property access
@@ -75,7 +72,7 @@ function collectDescendants(item: unknown, results: unknown[]): void {
 
 /**
  * Parse a JSONPath expression into segments
- * Handles: $.foo.bar, $..foo, $[*], $.foo[*].bar
+ * Handles: $.foo.bar, $..foo, $[*], $.foo[*].bar, $["foo"], $['foo']
  */
 export function parseJsonPath(path: string): string[] {
   if (!path.startsWith("$")) {
@@ -108,7 +105,7 @@ export function parseJsonPath(path: string): string[] {
       if (end === -1) break;
       
       const content = current.slice(1, end);
-      segments.push(content);
+      segments.push(unquoteBracketSegment(content));
       current = current.slice(end + 1);
     } else {
       break;
@@ -116,4 +113,13 @@ export function parseJsonPath(path: string): string[] {
   }
   
   return segments;
+}
+
+function unquoteBracketSegment(segment: string): string {
+  const quote = segment[0];
+  if ((quote === "\"" || quote === "'") && segment[segment.length - 1] === quote) {
+    return segment.slice(1, -1).replace(/\\(["'\\])/g, "$1");
+  }
+
+  return segment;
 }

--- a/tests/integration/nested-ref-registry.test.ts
+++ b/tests/integration/nested-ref-registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { generate } from "../../src/index.js";
+
+describe("nested schema $defs registration", () => {
+  test("resolves local refs from a reused nested schema document", async () => {
+    const mainSchema = {
+      $defs: {
+        FirstRegistrationData: {
+          type: "object",
+          additionalProperties: false,
+        },
+      },
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        firstRegistrationData: {
+          $ref: "#/$defs/FirstRegistrationData",
+        },
+      },
+    } as const;
+
+    const result = await generate({
+      type: "object",
+      properties: {
+        extras: {
+          schema: mainSchema,
+        },
+      },
+      required: ["extras"],
+    }, {
+      alwaysFakeOptionals: true,
+    }) as { extras: { schema: { firstRegistrationData: Record<string, unknown> } } };
+
+    expect(result.extras.schema.firstRegistrationData).toEqual({});
+  });
+});

--- a/tests/unit/extensions.test.ts
+++ b/tests/unit/extensions.test.ts
@@ -235,5 +235,46 @@ describe("extensions API", () => {
       expect(receivedPath).toBe("/properties/user/properties/name");
       expect(receivedOutputPath).toBe("/user/name");
     });
+
+    test("allows custom keywords to generate from a subschema through ctx.proceed", async () => {
+      const callback: ExtensionCallback = async function (value, _schema, ctx) {
+        return {
+          wrapped: await ctx.proceed!(value as JsonSchemaObject),
+        };
+      };
+      define("wrapGenerated", callback);
+
+      const result = await generate({
+        type: "object",
+        properties: {
+          payload: {
+            wrapGenerated: {
+              type: "object",
+              properties: {
+                name: { const: "generated-name" },
+              },
+              required: ["name"],
+            },
+          },
+        },
+        required: ["payload"],
+      }) as { payload: { wrapped: { name: string } } };
+
+      expect(result.payload.wrapped).toEqual({ name: "generated-name" });
+    });
+
+    test("awaits async custom keyword callbacks", async () => {
+      define("asyncValue", async function () {
+        await Promise.resolve();
+        return "async-result";
+      });
+
+      const result = await generate({
+        type: "string",
+        asyncValue: true,
+      });
+
+      expect(result).toBe("async-result");
+    });
   });
 });

--- a/tests/unit/jsonpath.test.ts
+++ b/tests/unit/jsonpath.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { evaluateJsonPath, parseJsonPath } from "../../src/utils/jsonpath.js";
+
+describe("JSONPath utilities", () => {
+  test("evaluates bracket-quoted keys", () => {
+    expect(evaluateJsonPath('$["key"]', { key: 42 })).toEqual([42]);
+    expect(evaluateJsonPath("$['key']", { key: 42 })).toEqual([42]);
+  });
+
+  test("evaluates mixed dot and bracket-quoted paths", () => {
+    expect(evaluateJsonPath('$.foo["bar-baz"]', {
+      foo: {
+        "bar-baz": "value",
+      },
+    })).toEqual(["value"]);
+  });
+
+  test("preserves recursive-descent segments while parsing", () => {
+    expect(parseJsonPath("$..name")).toEqual(["", "name"]);
+    expect(evaluateJsonPath("$..name", {
+      user: { name: "Ada" },
+      team: [{ name: "Grace" }],
+    })).toEqual(["Ada", "Grace"]);
+  });
+});

--- a/tests/unit/primitives.test.ts
+++ b/tests/unit/primitives.test.ts
@@ -95,6 +95,50 @@ describe("integer generator", () => {
     ]);
   });
 
+  test("keeps autoIncrement counters independent for digit-only property names", async () => {
+    const val = await generate({
+      type: "array",
+      minItems: 3,
+      maxItems: 3,
+      items: {
+        type: "object",
+        properties: {
+          "0": { type: "integer", autoIncrement: true },
+          "1": { type: "integer", autoIncrement: true },
+        },
+        required: ["0", "1"],
+      },
+    }) as Array<{ "0": number; "1": number }>;
+
+    expect(val).toEqual([
+      { "0": 1, "1": 1 },
+      { "0": 2, "1": 2 },
+      { "0": 3, "1": 3 },
+    ]);
+  });
+
+  test("keeps autoIncrement counters independent for slash-containing property names", async () => {
+    const val = await generate({
+      type: "array",
+      minItems: 3,
+      maxItems: 3,
+      items: {
+        type: "object",
+        properties: {
+          a: { type: "integer", autoIncrement: true },
+          "a/": { type: "integer", autoIncrement: true },
+        },
+        required: ["a", "a/"],
+      },
+    }) as Array<{ a: number; "a/": number }>;
+
+    expect(val).toEqual([
+      { a: 1, "a/": 1 },
+      { a: 2, "a/": 2 },
+      { a: 3, "a/": 3 },
+    ]);
+  });
+
   test("respects bounds", async () => {
     const schema = { type: "integer" as const, minimum: 1, maximum: 10 };
     for (let seed = 1; seed <= 50; seed++) {


### PR DESCRIPTION
## Summary

Five independent, previously-reported bugs, fixed as one batch (one commit each,
easy to revert individually):

- **#869** — `$ref` failed to resolve (`Unresolved $ref: #/$defs/X`) when a full
  schema document (with its own `$defs`) is reused as a nested subschema value
  without an `$id`. `walk()` now registers a visited schema's own `$defs` into the
  ref registry on first visit, only filling in names the root registry doesn't
  already have — so root-registered `$defs` still take precedence.
- **#871** — custom keyword extensions (`jsf.define`) had no way to recurse into a
  subschema through the engine. Extensions now receive `ctx.proceed(schema, overrides?)`,
  and the extension registry is properly `async`/`await`-aware so a `Promise` doesn't
  leak into `outputTransform` when a callback uses it.
- **#872** — `autoIncrement` counters collided for digit-only property names (e.g.
  `"0"`, `"1"`) and for names containing `/` (e.g. `"a/"`). The counter-key builder no
  longer guesses "array index" from a bare digit regex; it only treats a numeric
  segment as an index when the segment immediately before it is the structural
  `"items"` path segment. Property-path segments are also now escaped consistently
  with how `outputPath` already was, fixing the `/`-in-key collision.
- **#873** — `parseJsonPath` was dead code and `evaluateJsonPath` couldn't resolve
  bracket-quoted keys like `$["key"]`. `evaluateJsonPath` now tokenizes through
  `parseJsonPath`, which gained bracket-quote support (`$["key"]` / `$['key']`,
  including hyphenated/otherwise-unreachable-via-dot-notation keys).
- **#874** — removed an unused `hasExplicitItems` const in `array.ts` (dead leftover
  from a refactor, zero other references).

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` — 514/514 pass, including new/extended regression coverage for all
      five issues (`tests/unit/primitives.test.ts`, `tests/unit/extensions.test.ts`,
      `tests/unit/jsonpath.test.ts`, `tests/integration/nested-ref-registry.test.ts`)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)