### PR TITLE
fix: address review feedback on #876 — scoped , quoted JSONPath keys, recursive descent

### DIFF
--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -208,22 +208,45 @@ export async function walk(schema: JsonSchema, ctx: GenerateContext): Promise<un
     throw new Error(`Cannot generate value for 'false' schema at ${ctx.path}`);
   }
 
+  // Register this schema's own $defs into the shared ref registry,
+  // saving previous entries so we can restore them after walking.
+  // This gives each schema document local scoping: when two reused
+  // nested schemas define the same $defs name, each resolves its own
+  // $ref during its walk instead of colliding via first-wins.
+  let prevDefs: Array<[string, JsonSchema | undefined]> | null = null;
   if (typeof schema === "object" && schema !== null && schema.$defs) {
+    prevDefs = [];
     for (const [name, def] of Object.entries(schema.$defs)) {
       const key = `#/$defs/${name}`;
-      if (!ctx.refRegistry.has(key)) {
-        ctx.refRegistry.set(key, def);
-      }
+      prevDefs.push([key, ctx.refRegistry.has(key) ? ctx.refRegistry.get(key) : undefined]);
+      ctx.refRegistry.set(key, def);
     }
   }
 
+  try {
+    return await walkSchemaBody(schema as JsonSchemaObject, ctx);
+  } finally {
+    // Restore previous $defs entries so each schema document gets
+    // local scoping — root-registered $defs still take precedence.
+    if (prevDefs) {
+      for (const [key, prev] of prevDefs) {
+        if (prev === undefined) {
+          ctx.refRegistry.delete(key);
+        } else {
+          ctx.refRegistry.set(key, prev);
+        }
+      }
+    }
+  }
+}
+
+async function walkSchemaBody(schema: JsonSchemaObject, ctx: GenerateContext): Promise<unknown> {
   // Apply propAliases: remap custom schema keys to known ones before processing
-  if (ctx.propAliases && typeof schema === 'object' && schema !== null) {
-    const schemaObj = schema as JsonSchemaObject;
+  if (ctx.propAliases) {
     let patched: JsonSchemaObject | null = null;
     for (const [from, to] of Object.entries(ctx.propAliases)) {
-      if (from in schemaObj && !(to in schemaObj)) {
-        if (!patched) patched = { ...schemaObj };
+      if (from in schema && !(to in schema)) {
+        if (!patched) patched = { ...schema };
         patched[to] = patched[from];
         delete patched[from];
       }

--- a/src/utils/jsonpath.ts
+++ b/src/utils/jsonpath.ts
@@ -19,11 +19,31 @@ export function evaluateJsonPath(path: string, data: unknown): unknown[] {
   
   for (const segment of segments) {
     const newResults: unknown[] = [];
+
+    // Recursive descent (..) — represented as empty segment.
+    // Collect all descendants of every current result, then include the
+    // current results themselves so the *next* segment also matches
+    // direct properties (e.g. $..name matches { name: "root", child: { name: "nested" } }).
+    if (segment === "") {
+      for (const item of results) {
+        collectDescendants(item, newResults);
+      }
+      newResults.push(...results);
+      results = newResults;
+      continue;
+    }
     
     for (const item of results) {
       if (item === null || item === undefined) continue;
       
-      if (segment === "*") {
+      // Quoted segments (prefixed "q:") are always property access,
+      // even when the unquoted value looks numeric (e.g. $["0"]).
+      if (segment.startsWith("q:")) {
+        const key = segment.slice(2);
+        if (typeof item === "object" && item !== null && key in item) {
+          newResults.push((item as Record<string, unknown>)[key]);
+        }
+      } else if (segment === "*") {
         // Array wildcard
         if (Array.isArray(item)) {
           newResults.push(...item);
@@ -34,9 +54,6 @@ export function evaluateJsonPath(path: string, data: unknown): unknown[] {
         if (Array.isArray(item) && index < item.length) {
           newResults.push(item[index]);
         }
-      } else if (segment === "") {
-        // Recursive descent operator (..)
-        collectDescendants(item, newResults);
       } else {
         // Property access
         if (typeof item === "object" && item !== null && segment in item) {
@@ -105,7 +122,11 @@ export function parseJsonPath(path: string): string[] {
       if (end === -1) break;
       
       const content = current.slice(1, end);
-      segments.push(unquoteBracketSegment(content));
+      const unquoted = unquoteBracketSegment(content);
+      // Prefix quoted segments so evaluateJsonPath can distinguish
+      // a quoted numeric key like "0" from an array index 0.
+      const wasQuoted = (content[0] === '"' || content[0] === "'");
+      segments.push(wasQuoted ? `q:${unquoted}` : unquoted);
       current = current.slice(end + 1);
     } else {
       break;

--- a/tests/integration/nested-ref-registry.test.ts
+++ b/tests/integration/nested-ref-registry.test.ts
@@ -33,4 +33,79 @@ describe("nested schema $defs registration", () => {
 
     expect(result.extras.schema.firstRegistrationData).toEqual({});
   });
+
+  test("scopes $defs per schema document — conflicting names resolve independently", async () => {
+    const schemaA = {
+      type: "object",
+      $defs: {
+        X: { type: "string", const: "from-A" },
+      },
+      properties: {
+        ref: { $ref: "#/$defs/X" },
+      },
+      required: ["ref"],
+    };
+
+    const schemaB = {
+      type: "object",
+      $defs: {
+        X: { type: "string", const: "from-B" },
+      },
+      properties: {
+        ref: { $ref: "#/$defs/X" },
+      },
+      required: ["ref"],
+    };
+
+    const mainSchema = {
+      type: "object",
+      properties: {
+        a: schemaA,
+        b: schemaB,
+      },
+      required: ["a", "b"],
+    };
+
+    const result = await generate(mainSchema) as {
+      a: { ref: string };
+      b: { ref: string };
+    };
+
+    // Each nested schema should resolve its own $ref to its own $defs.X
+    expect(result.a.ref).toBe("from-A");
+    expect(result.b.ref).toBe("from-B");
+  });
+
+  test("root $defs are visible to root-level refs while nested $defs are scoped locally", async () => {
+    const mainSchema = {
+      type: "object",
+      $defs: {
+        Shared: { type: "string", const: "root-value" },
+      },
+      properties: {
+        nested: {
+          type: "object",
+          $defs: {
+            Shared: { type: "string", const: "nested-value" },
+          },
+          properties: {
+            ref: { $ref: "#/$defs/Shared" },
+          },
+          required: ["ref"],
+        },
+        rootRef: { $ref: "#/$defs/Shared" },
+      },
+      required: ["nested", "rootRef"],
+    };
+
+    const result = await generate(mainSchema) as {
+      nested: { ref: string };
+      rootRef: string;
+    };
+
+    // Root $defs are visible to root-level refs
+    expect(result.rootRef).toBe("root-value");
+    // Nested schema resolves its own $defs.Shared locally (document-local scoping)
+    expect(result.nested.ref).toBe("nested-value");
+  });
 });

--- a/tests/unit/jsonpath.test.ts
+++ b/tests/unit/jsonpath.test.ts
@@ -22,4 +22,32 @@ describe("JSONPath utilities", () => {
       team: [{ name: "Grace" }],
     })).toEqual(["Ada", "Grace"]);
   });
+
+  test("preserves quoted numeric keys as property names, not array indices", () => {
+    const data = { "0": "zero", "1": "one", 2: "two" };
+    // $["0"] should access the property named "0"
+    expect(evaluateJsonPath('$["0"]', data)).toEqual(["zero"]);
+    expect(evaluateJsonPath("$['0']", data)).toEqual(["zero"]);
+    // $[0] (unquoted) should access array index 0
+    expect(evaluateJsonPath("$[0]", ["a", "b", "c"])).toEqual(["a"]);
+  });
+
+  test("recursive descent includes direct properties of the current object", () => {
+    const data = {
+      name: "root",
+      child: { name: "nested" },
+    };
+    // $..name should match both root.name and child.name
+    expect(evaluateJsonPath("$..name", data)).toEqual(["nested", "root"]);
+  });
+
+  test("recursive descent works with nested arrays", () => {
+    const data = {
+      items: [
+        { name: "first" },
+        { name: "second" },
+      ],
+    };
+    expect(evaluateJsonPath("$..name", data)).toEqual(["first", "second"]);
+  });
 });


### PR DESCRIPTION
## Summary

Addresses the three review comments left on #876:

- **P1 — Scope nested `$defs`** (`src/schema-walker.ts`): Each visited schema now saves/restores its `$defs` entries in the shared registry via try/finally around the body walk. Two reused nested schemas defining the same `$defs` name each resolve their own `$ref` during their walk instead of colliding via first-wins. Extracted post-`$defs` processing into `walkSchemaBody()` so the restore happens on every exit path.

- **P2 — Preserve quoted numeric JSONPath keys** (`src/utils/jsonpath.ts`): `parseJsonPath` prefixes quoted bracket segments with `q:` (e.g. `$["0"]` → `q:0`). `evaluateJsonPath` treats `q:`-prefixed segments as property access, not array indices, so `$["0"]` correctly accesses the property named `"0"`.

- **P2 — Include direct properties in recursive descent** (`src/utils/jsonpath.ts`): `$..name` now matches `name` on both the current object and all descendants. Restructured `evaluateJsonPath` to handle the recursive descent segment outside the per-item loop.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` — 519/519 pass
- [x] `bun run build`