### PR TITLE
feat: add synchronous generateSync/createGeneratorSync API (#854)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ const a = await gen.generate(schema); // seed 42
 const b = await gen.generate(schema); // seed 43
 ```
 
+### `generateSync(schema, options?)`
+
+Synchronous variant of `generate()` for in-memory schemas. Returns the value directly (no `Promise`).
+
+```typescript
+const value = generateSync({ type: "string", format: "email" });
+```
+
+Sync mode only supports schemas that are fully resolvable without I/O:
+
+- No `refResolver` option — pre-resolve any remote `$ref`s before calling `generateSync()`. A remote `$ref` that isn't already registered throws.
+- Custom extensions (`define()`) and `outputTransform` must be synchronous — an async callback throws `Cannot use async extension '<name>' in generateSync()` / `Cannot use async outputTransform in generateSync()` instead of silently returning a `Promise`.
+
+All other options behave the same as `generate()`.
+
+### `createGeneratorSync(options?)`
+
+Synchronous variant of `createGenerator()`.
+
+```typescript
+const gen = createGeneratorSync({ seed: 42 });
+const a = gen.generate(schema); // seed 42
+const b = gen.generate(schema); // seed 43
+```
+
 ### `registerFormat(name, generator)`
 
 Register a custom format generator globally.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ const value = generateSync({ type: "string", format: "email" });
 
 Sync mode only supports schemas that are fully resolvable without I/O:
 
-- No `refResolver` option — pre-resolve any remote `$ref`s before calling `generateSync()`. A remote `$ref` that isn't already registered throws.
-- Custom extensions (`define()`) and `outputTransform` must be synchronous — an async callback throws `Cannot use async extension '<name>' in generateSync()` / `Cannot use async outputTransform in generateSync()` instead of silently returning a `Promise`.
+- A remote `$ref` that isn't already registered and has no `refResolver` throws.
+- `refResolver`, custom extensions (`define()`), and `outputTransform` must be synchronous — if one returns a `Promise`, `generateSync()` throws immediately (`Cannot use async refResolver in generateSync()` / `Cannot use async extension '<name>' in generateSync()` / `Cannot use async outputTransform in generateSync()`) instead of silently returning a `Promise`. A `refResolver` that returns plain values (e.g. reading from an in-memory map) works fine in sync mode.
 
 All other options behave the same as `generate()`.
 

--- a/src/coroutine.ts
+++ b/src/coroutine.ts
@@ -1,0 +1,45 @@
+export type Gen<T> = Generator<unknown, T, unknown>;
+
+export function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return typeof value === "object" && value !== null && "then" in value && typeof (value as { then: unknown }).then === "function";
+}
+
+export async function runAsync<T>(gen: Gen<T>): Promise<T> {
+  let sent: unknown;
+  let threw: unknown;
+  let hasThrown = false;
+
+  for (;;) {
+    const step = hasThrown ? gen.throw(threw) : gen.next(sent);
+    hasThrown = false;
+
+    if (step.done) {
+      return step.value;
+    }
+
+    try {
+      sent = await step.value;
+    } catch (err) {
+      hasThrown = true;
+      threw = err;
+    }
+  }
+}
+
+export function runSync<T>(gen: Gen<T>): T {
+  let sent: unknown;
+
+  for (;;) {
+    const step = gen.next(sent);
+
+    if (step.done) {
+      return step.value;
+    }
+
+    if (isPromiseLike(step.value)) {
+      throw new Error("generateSync() encountered an unexpected asynchronous operation.");
+    }
+
+    sent = step.value;
+  }
+}

--- a/src/coroutine.ts
+++ b/src/coroutine.ts
@@ -1,45 +1,139 @@
+import type { JsonSchema, GenerateContext } from "./types.js";
+
 export type Gen<T> = Generator<unknown, T, unknown>;
 
 export function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return typeof value === "object" && value !== null && "then" in value && typeof (value as { then: unknown }).then === "function";
 }
 
-export async function runAsync<T>(gen: Gen<T>): Promise<T> {
-  let sent: unknown;
-  let threw: unknown;
-  let hasThrown = false;
+const WALK_CALL = Symbol("walkCall");
+
+/**
+ * Marker yielded (not yield*-delegated) to request a nested schema walk.
+ * The trampoline in runAsync/runSync spawns it as an independent generator
+ * on an explicit stack instead of native `yield*` delegation, so recursion
+ * depth (deep $ref chains, deeply nested required trees) doesn't grow the
+ * JS call stack — see #879 review feedback re: stack overflow on deep refs.
+ */
+export interface WalkCall {
+  readonly [WALK_CALL]: true;
+  readonly schema: JsonSchema;
+  readonly ctx: GenerateContext;
+}
+
+export function walkCall(schema: JsonSchema, ctx: GenerateContext): WalkCall {
+  return { [WALK_CALL]: true, schema, ctx };
+}
+
+function isWalkCall(value: unknown): value is WalkCall {
+  return typeof value === "object" && value !== null && WALK_CALL in value;
+}
+
+type Spawn = (schema: JsonSchema, ctx: GenerateContext) => Gen<unknown>;
+
+interface Frame {
+  gen: Gen<unknown>;
+  sent: unknown;
+  hasThrown: boolean;
+  threw: unknown;
+}
+
+function pushFrame(stack: Frame[], gen: Gen<unknown>): void {
+  stack.push({ gen, sent: undefined, hasThrown: false, threw: undefined });
+}
+
+/**
+ * Steps the top-of-stack frame. If it throws (either because the frame's own
+ * body threw, or because a spawned child frame we're forwarding an error into
+ * rethrew), the error is routed into the new top-of-stack frame via `.throw()`
+ * on the next iteration — mirroring how `yield*` propagates a delegate's
+ * exception back to the try/catch around the original `yield*` expression.
+ * Returns `undefined` (via mutating `stack`) when the whole trampoline should
+ * keep looping; the caller distinguishes completion via `stack.length`.
+ */
+function step(stack: Frame[]): IteratorResult<unknown, unknown> | undefined {
+  const frame = stack[stack.length - 1];
+  let result: IteratorResult<unknown, unknown>;
+
+  try {
+    result = frame.hasThrown ? frame.gen.throw(frame.threw) : frame.gen.next(frame.sent);
+  } catch (err) {
+    stack.pop();
+    if (stack.length === 0) {
+      throw err;
+    }
+    const parent = stack[stack.length - 1];
+    parent.hasThrown = true;
+    parent.threw = err;
+    return undefined;
+  }
+
+  frame.hasThrown = false;
+  return result;
+}
+
+export async function runAsync<T>(rootGen: Gen<T>, spawn: Spawn): Promise<T> {
+  const stack: Frame[] = [];
+  pushFrame(stack, rootGen as Gen<unknown>);
 
   for (;;) {
-    const step = hasThrown ? gen.throw(threw) : gen.next(sent);
-    hasThrown = false;
-
-    if (step.done) {
-      return step.value;
+    const result = step(stack);
+    if (result === undefined) {
+      continue;
     }
 
+    if (result.done) {
+      stack.pop();
+      if (stack.length === 0) {
+        return result.value as T;
+      }
+      stack[stack.length - 1].sent = result.value;
+      continue;
+    }
+
+    if (isWalkCall(result.value)) {
+      pushFrame(stack, spawn(result.value.schema, result.value.ctx));
+      continue;
+    }
+
+    const frame = stack[stack.length - 1];
     try {
-      sent = await step.value;
+      frame.sent = await result.value;
     } catch (err) {
-      hasThrown = true;
-      threw = err;
+      frame.hasThrown = true;
+      frame.threw = err;
     }
   }
 }
 
-export function runSync<T>(gen: Gen<T>): T {
-  let sent: unknown;
+export function runSync<T>(rootGen: Gen<T>, spawn: Spawn): T {
+  const stack: Frame[] = [];
+  pushFrame(stack, rootGen as Gen<unknown>);
 
   for (;;) {
-    const step = gen.next(sent);
-
-    if (step.done) {
-      return step.value;
+    const result = step(stack);
+    if (result === undefined) {
+      continue;
     }
 
-    if (isPromiseLike(step.value)) {
+    if (result.done) {
+      stack.pop();
+      if (stack.length === 0) {
+        return result.value as T;
+      }
+      stack[stack.length - 1].sent = result.value;
+      continue;
+    }
+
+    if (isWalkCall(result.value)) {
+      pushFrame(stack, spawn(result.value.schema, result.value.ctx));
+      continue;
+    }
+
+    if (isPromiseLike(result.value)) {
       throw new Error("generateSync() encountered an unexpected asynchronous operation.");
     }
 
-    sent = step.value;
+    stack[stack.length - 1].sent = result.value;
   }
 }

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -63,6 +63,9 @@ class ExtensionRegistry {
         const raw = entry.callback.call(entry.context, value, schema, ctx);
 
         if (ctx.__sync && isPromiseLike(raw)) {
+          // Swallow the rejection so it doesn't surface as an unhandled promise
+          // rejection after we throw synchronously below.
+          Promise.resolve(raw).catch(() => {});
           throw new Error(`Cannot use async extension '${extName}' in generateSync()`);
         }
 

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,4 +1,5 @@
 import type { JsonSchemaObject, GenerateContext } from "./types.js";
+import { type Gen, isPromiseLike } from "./coroutine.js";
 
 export type ExtensionCallback = (
   this: ExtensionContext,
@@ -46,10 +47,10 @@ class ExtensionRegistry {
     return this.extensions.keys();
   }
 
-  async generate(
+  *generateGen(
     schema: JsonSchemaObject,
     ctx: GenerateContext
-  ): Promise<unknown> {
+  ): Gen<unknown> {
     const keys = Object.keys(schema);
 
     for (let i = keys.length - 1; i >= 0; i--) {
@@ -59,7 +60,13 @@ class ExtensionRegistry {
 
       if (entry) {
         const value = schema[key];
-        const result = await entry.callback.call(entry.context, value, schema, ctx);
+        const raw = entry.callback.call(entry.context, value, schema, ctx);
+
+        if (ctx.__sync && isPromiseLike(raw)) {
+          throw new Error(`Cannot use async extension '${extName}' in generateSync()`);
+        }
+
+        const result = yield raw;
 
         if (result !== undefined) {
           return result;
@@ -92,11 +99,11 @@ export function resetExtension(name?: string): void {
   globalExtensions.reset(name);
 }
 
-export function generateFromExtensions(
+export function* generateFromExtensionsGen(
   schema: JsonSchemaObject,
   ctx: GenerateContext
-): Promise<unknown> {
-  return globalExtensions.generate(schema, ctx);
+): Gen<unknown> {
+  return yield* globalExtensions.generateGen(schema, ctx);
 }
 
 export function getExtensionContext(name: string): ExtensionContext | undefined {

--- a/src/generators/array.ts
+++ b/src/generators/array.ts
@@ -1,10 +1,11 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "../types.js";
-import { walk } from "../schema-walker.js";
+import { walkGen } from "../schema-walker.js";
+import { type Gen } from "../coroutine.js";
 
-export async function generateArray(
+export function* generateArrayGen(
   schema: JsonSchemaObject,
   ctx: GenerateContext
-): Promise<unknown[]> {
+): Gen<unknown[]> {
   if (ctx.depth >= ctx.maxDepth) {
     const needed = schema.minItems ?? 0;
     return needed > 0 ? Array.from({ length: needed }, () => null) : [];
@@ -69,8 +70,8 @@ export async function generateArray(
   const seen = schema.uniqueItems ? new Set<string>() : null;
 
   // Helper to add item with uniqueness check
-  const addItem = async (itemSchema: JsonSchema, itemCtx: GenerateContext): Promise<"added" | "omitted" | "failed"> => {
-    let item = await walk(itemSchema, itemCtx);
+  function* addItemGen(itemSchema: JsonSchema, itemCtx: GenerateContext): Gen<"added" | "omitted" | "failed"> {
+    let item = yield* walkGen(itemSchema, itemCtx);
     if (item === undefined) {
       return "omitted";
     }
@@ -80,7 +81,7 @@ export async function generateArray(
       if (seen.has(key)) {
         // Try to generate a unique item (limited attempts)
         for (let attempts = 0; attempts < 50; attempts++) {
-          item = await walk(itemSchema, createItemContext(childCtx, result.length));
+          item = yield* walkGen(itemSchema, createItemContext(childCtx, result.length));
           if (item === undefined) {
             continue;
           }
@@ -98,13 +99,13 @@ export async function generateArray(
 
     result.push(item);
     return "added";
-  };
+  }
 
   // Handle prefixItems (Draft 2020-12 tuple syntax)
   if (schema.prefixItems) {
     for (let i = 0; i < schema.prefixItems.length && result.length < maxItems; i++) {
       const itemCtx = createItemContext(childCtx, i);
-      const status = await addItem(schema.prefixItems[i], itemCtx);
+      const status = yield* addItemGen(schema.prefixItems[i], itemCtx);
       if (status === "failed") break;
     }
   }
@@ -164,7 +165,7 @@ export async function generateArray(
     let attempts = 0;
     const maxAttempts = Math.max(targetLen * 20, 50);
     while (result.length < targetLen) {
-      const status = await addItem(itemSchema, createItemContext(childCtx, result.length));
+      const status = yield* addItemGen(itemSchema, createItemContext(childCtx, result.length));
       if (status === "added") {
         attempts = 0;
         continue;
@@ -181,7 +182,7 @@ export async function generateArray(
     const containsCount = ctx.random.int(minContains, maxContains);
 
     for (let i = 0; i < containsCount; i++) {
-      let item = await walk(schema.contains, createItemContext(childCtx, result.length));
+      let item = yield* walkGen(schema.contains, createItemContext(childCtx, result.length));
       if (item === undefined) {
         continue;
       }
@@ -193,7 +194,7 @@ export async function generateArray(
           // Try to generate unique item
           let uniqueFound = false;
           for (let attempts = 0; attempts < 50; attempts++) {
-            item = await walk(schema.contains, createItemContext(childCtx, result.length));
+            item = yield* walkGen(schema.contains, createItemContext(childCtx, result.length));
             if (item === undefined) {
               continue;
             }
@@ -231,7 +232,7 @@ export async function generateArray(
     const claimedPositions = new Set<number>();
 
     for (const containsSchema of schema.containsAll) {
-      let item = await walk(containsSchema, createItemContext(childCtx, result.length));
+      let item = yield* walkGen(containsSchema, createItemContext(childCtx, result.length));
       if (item === undefined) {
         continue;
       }
@@ -241,7 +242,7 @@ export async function generateArray(
         if (seen.has(key)) {
           let uniqueFound = false;
           for (let attempts = 0; attempts < 50; attempts++) {
-            item = await walk(containsSchema, createItemContext(childCtx, result.length));
+            item = yield* walkGen(containsSchema, createItemContext(childCtx, result.length));
             if (item === undefined) {
               continue;
             }
@@ -294,20 +295,20 @@ export async function generateArray(
 
   // Handle uniqueItems - fill up to minItems if needed
   if (schema.uniqueItems && result.length > 0) {
-    return fillUniqueItems(result, schema, childCtx, minItems, maxItems, seen!);
+    return yield* fillUniqueItemsGen(result, schema, childCtx, minItems, maxItems, seen!);
   }
 
   return result;
 }
 
-async function fillUniqueItems(
+function* fillUniqueItemsGen(
   arr: unknown[],
   schema: JsonSchemaObject,
   ctx: GenerateContext,
   minItems: number,
   maxItems: number,
   seen: Set<string>
-): Promise<unknown[]> {
+): Gen<unknown[]> {
   const itemSchema: JsonSchema = schema.items ?? {};
 
   // Try to fill up to minItems with unique values
@@ -316,7 +317,7 @@ async function fillUniqueItems(
 
   while (arr.length < minItems && attempts < maxAttempts) {
     attempts++;
-    const item = await walk(itemSchema, createItemContext(ctx, arr.length));
+    const item = yield* walkGen(itemSchema, createItemContext(ctx, arr.length));
     if (item === undefined) {
       continue;
     }

--- a/src/generators/array.ts
+++ b/src/generators/array.ts
@@ -1,6 +1,5 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "../types.js";
-import { walkGen } from "../schema-walker.js";
-import { type Gen } from "../coroutine.js";
+import { type Gen, walkCall } from "../coroutine.js";
 
 export function* generateArrayGen(
   schema: JsonSchemaObject,
@@ -71,7 +70,7 @@ export function* generateArrayGen(
 
   // Helper to add item with uniqueness check
   function* addItemGen(itemSchema: JsonSchema, itemCtx: GenerateContext): Gen<"added" | "omitted" | "failed"> {
-    let item = yield* walkGen(itemSchema, itemCtx);
+    let item = yield walkCall(itemSchema, itemCtx);
     if (item === undefined) {
       return "omitted";
     }
@@ -81,7 +80,7 @@ export function* generateArrayGen(
       if (seen.has(key)) {
         // Try to generate a unique item (limited attempts)
         for (let attempts = 0; attempts < 50; attempts++) {
-          item = yield* walkGen(itemSchema, createItemContext(childCtx, result.length));
+          item = yield walkCall(itemSchema, createItemContext(childCtx, result.length));
           if (item === undefined) {
             continue;
           }
@@ -182,7 +181,7 @@ export function* generateArrayGen(
     const containsCount = ctx.random.int(minContains, maxContains);
 
     for (let i = 0; i < containsCount; i++) {
-      let item = yield* walkGen(schema.contains, createItemContext(childCtx, result.length));
+      let item = yield walkCall(schema.contains, createItemContext(childCtx, result.length));
       if (item === undefined) {
         continue;
       }
@@ -194,7 +193,7 @@ export function* generateArrayGen(
           // Try to generate unique item
           let uniqueFound = false;
           for (let attempts = 0; attempts < 50; attempts++) {
-            item = yield* walkGen(schema.contains, createItemContext(childCtx, result.length));
+            item = yield walkCall(schema.contains, createItemContext(childCtx, result.length));
             if (item === undefined) {
               continue;
             }
@@ -232,7 +231,7 @@ export function* generateArrayGen(
     const claimedPositions = new Set<number>();
 
     for (const containsSchema of schema.containsAll) {
-      let item = yield* walkGen(containsSchema, createItemContext(childCtx, result.length));
+      let item = yield walkCall(containsSchema, createItemContext(childCtx, result.length));
       if (item === undefined) {
         continue;
       }
@@ -242,7 +241,7 @@ export function* generateArrayGen(
         if (seen.has(key)) {
           let uniqueFound = false;
           for (let attempts = 0; attempts < 50; attempts++) {
-            item = yield* walkGen(containsSchema, createItemContext(childCtx, result.length));
+            item = yield walkCall(containsSchema, createItemContext(childCtx, result.length));
             if (item === undefined) {
               continue;
             }
@@ -317,7 +316,7 @@ function* fillUniqueItemsGen(
 
   while (arr.length < minItems && attempts < maxAttempts) {
     attempts++;
-    const item = yield* walkGen(itemSchema, createItemContext(ctx, arr.length));
+    const item = yield walkCall(itemSchema, createItemContext(ctx, arr.length));
     if (item === undefined) {
       continue;
     }

--- a/src/generators/composition.ts
+++ b/src/generators/composition.ts
@@ -1,6 +1,5 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "../types.js";
-import { walkGen } from "../schema-walker.js";
-import { type Gen } from "../coroutine.js";
+import { type Gen, walkCall } from "../coroutine.js";
 import { mergeSchemas } from "../merge.js";
 import { resolveRefGen } from "../ref-resolver.js";
 
@@ -33,7 +32,7 @@ export function* generateCompositionGen(
   if (allOf) {
     const resolvedRefs = yield* resolveAllOfRefsGen(allOf, ctx);
     const merged = mergeSchemas([base, ...resolvedRefs]);
-    return yield* walkGen(merged, ctx);
+    return yield walkCall(merged, ctx);
   }
 
   if (oneOf) {
@@ -72,7 +71,7 @@ export function* generateCompositionGen(
       };
 
       try {
-        return yield* walkGen(merged, oneOfCtx);
+        return yield walkCall(merged, oneOfCtx);
       } catch {
         // Try next branch
       }
@@ -99,7 +98,7 @@ export function* generateCompositionGen(
       optionalsProbability: 0,
       alwaysFakeOptionals: false,
     };
-    return yield* walkGen(merged, oneOfCtx);
+    return yield walkCall(merged, oneOfCtx);
   }
 
   if (anyOf) {
@@ -109,7 +108,7 @@ export function* generateCompositionGen(
     for (const branch of branches) {
       const merged = mergeSchemas([base, branch]);
       try {
-        return yield* walkGen(merged, ctx);
+        return yield walkCall(merged, ctx);
       } catch {
         // Try next branch
       }
@@ -117,7 +116,7 @@ export function* generateCompositionGen(
     // If all fail, try the first one anyway
     const picked = anyOf[0];
     const merged = mergeSchemas([base, picked]);
-    return yield* walkGen(merged, ctx);
+    return yield walkCall(merged, ctx);
   }
 
   if (ifSchema !== undefined) {
@@ -128,7 +127,7 @@ export function* generateCompositionGen(
     return yield* generateNotGen(base, not, ctx);
   }
 
-  return yield* walkGen(base, ctx);
+  return yield walkCall(base, ctx);
 }
 
 function* generateConditionalGen(
@@ -142,7 +141,7 @@ function* generateConditionalGen(
   if (thenSchema !== undefined) {
     const mergedIfThen = mergeSchemas([base, ifSchema, thenSchema]);
     try {
-      return yield* walkGen(mergedIfThen, ctx);
+      return yield walkCall(mergedIfThen, ctx);
     } catch {
       // If then branch fails, fall through to try else
     }
@@ -152,14 +151,14 @@ function* generateConditionalGen(
   if (elseSchema !== undefined) {
     const mergedElse = mergeSchemas([base, elseSchema]);
     try {
-      return yield* walkGen(mergedElse, ctx);
+      return yield walkCall(mergedElse, ctx);
     } catch {
       // If else also fails, fall through
     }
   }
 
   // Fallback: just try base schema
-  return yield* walkGen(base, ctx);
+  return yield walkCall(base, ctx);
 }
 
 function* generateNotGen(
@@ -173,7 +172,7 @@ function* generateNotGen(
       throw new Error(`Cannot generate value for 'not: true' at ${ctx.path}`);
     }
     // not false = everything is valid
-    return yield* walkGen(base, ctx);
+    return yield walkCall(base, ctx);
   }
 
   // Simple type avoidance
@@ -185,7 +184,7 @@ function* generateNotGen(
     if (allowed.length > 0) {
       const type = ctx.random.pick(allowed);
       const merged = mergeSchemas([base, { type }]);
-      return yield* walkGen(merged, ctx);
+      return yield walkCall(merged, ctx);
     }
   }
 
@@ -195,7 +194,7 @@ function* generateNotGen(
     const excluded = not.enum ?? [not.const];
     const excludedSet = new Set(excluded.map((v) => JSON.stringify(v)));
     for (let i = 0; i < 20; i++) {
-      const value = yield* walkGen(base, ctx);
+      const value = yield walkCall(base, ctx);
       if (!excludedSet.has(JSON.stringify(value))) {
         return value;
       }
@@ -203,5 +202,5 @@ function* generateNotGen(
   }
 
   // Fallback: generate from base
-  return yield* walkGen(base, ctx);
+  return yield walkCall(base, ctx);
 }

--- a/src/generators/composition.ts
+++ b/src/generators/composition.ts
@@ -1,19 +1,20 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "../types.js";
-import { walk } from "../schema-walker.js";
+import { walkGen } from "../schema-walker.js";
+import { type Gen } from "../coroutine.js";
 import { mergeSchemas } from "../merge.js";
-import { resolveRef } from "../ref-resolver.js";
+import { resolveRefGen } from "../ref-resolver.js";
 
-async function resolveSchemaRef(schema: JsonSchemaObject, ctx: GenerateContext): Promise<JsonSchemaObject> {
+function* resolveSchemaRefGen(schema: JsonSchemaObject, ctx: GenerateContext): Gen<JsonSchemaObject> {
   if (!schema.$ref) return schema;
-  const resolved = await resolveRef(schema, ctx);
+  const resolved = yield* resolveRefGen(schema, ctx);
   return resolved.schema as JsonSchemaObject;
 }
 
-async function resolveAllOfRefs(allOf: JsonSchema[], ctx: GenerateContext): Promise<JsonSchemaObject[]> {
+function* resolveAllOfRefsGen(allOf: JsonSchema[], ctx: GenerateContext): Gen<JsonSchemaObject[]> {
   const resolved: JsonSchemaObject[] = [];
   for (const item of allOf) {
     if (typeof item === "object" && item !== null && "$ref" in item) {
-      const res = await resolveSchemaRef(item as JsonSchemaObject, ctx);
+      const res = yield* resolveSchemaRefGen(item as JsonSchemaObject, ctx);
       resolved.push(res);
     } else if (typeof item === "object" && item !== null) {
       resolved.push(item as JsonSchemaObject);
@@ -22,56 +23,56 @@ async function resolveAllOfRefs(allOf: JsonSchema[], ctx: GenerateContext): Prom
   return resolved;
 }
 
-export async function generateComposition(
+export function* generateCompositionGen(
   schema: JsonSchemaObject,
   ctx: GenerateContext
-): Promise<unknown> {
+): Gen<unknown> {
   // Extract non-composition keywords as base schema
   const { allOf, anyOf, oneOf, not, if: ifSchema, then: thenSchema, else: elseSchema, ...base } = schema;
 
   if (allOf) {
-    const resolvedRefs = await resolveAllOfRefs(allOf, ctx);
+    const resolvedRefs = yield* resolveAllOfRefsGen(allOf, ctx);
     const merged = mergeSchemas([base, ...resolvedRefs]);
-    return walk(merged, ctx);
+    return yield* walkGen(merged, ctx);
   }
 
   if (oneOf) {
     const branches = ctx.random.shuffle([...oneOf]);
-    
+
     // Get required from base schema (from allOf merging)
     const baseRequired = base.required ?? [];
-    
+
     for (const branch of branches) {
       let branchObj = typeof branch === "object" && branch !== null ? branch : {};
-      
+
       // Resolve $ref if present to get the actual schema with required properties
       if (branchObj.$ref) {
-        const resolved = await resolveRef(branchObj, ctx);
+        const resolved = yield* resolveRefGen(branchObj, ctx);
         branchObj = resolved.schema as JsonSchemaObject;
       }
-      
+
       const branchRequired = branchObj.required ?? [];
       // Combine base required with branch required (union)
       const combinedRequired = [...new Set([...baseRequired, ...branchRequired])];
-      
+
       // Build base with properties but with combined required
       // Also set optionalsProbability to 0 to only generate required properties
-      const baseWithBranchRequired: JsonSchemaObject = { 
+      const baseWithBranchRequired: JsonSchemaObject = {
         ...base,
         required: combinedRequired
       };
-      
+
       const merged = mergeSchemas([baseWithBranchRequired, branchObj]);
-      
+
       // Create context with optionalsProbability: 0 to only generate required properties
       const oneOfCtx: GenerateContext = {
         ...ctx,
         optionalsProbability: 0,
         alwaysFakeOptionals: false,
       };
-      
+
       try {
-        return await walk(merged, oneOfCtx);
+        return yield* walkGen(merged, oneOfCtx);
       } catch {
         // Try next branch
       }
@@ -79,16 +80,16 @@ export async function generateComposition(
     // If all fail, try the first one anyway
     const picked = oneOf[0];
     let pickedObj = typeof picked === "object" && picked !== null ? picked : {};
-    
+
     // Resolve $ref if present to get the actual schema with required properties
     if (pickedObj.$ref) {
-      const resolved = await resolveRef(pickedObj, ctx);
+      const resolved = yield* resolveRefGen(pickedObj, ctx);
       pickedObj = resolved.schema as JsonSchemaObject;
     }
-    
+
     const pickedRequired = pickedObj.required ?? [];
     const combinedRequired = [...new Set([...baseRequired, ...pickedRequired])];
-    const baseWithPickedRequired: JsonSchemaObject = { 
+    const baseWithPickedRequired: JsonSchemaObject = {
       ...base,
       required: combinedRequired
     };
@@ -98,17 +99,17 @@ export async function generateComposition(
       optionalsProbability: 0,
       alwaysFakeOptionals: false,
     };
-    return walk(merged, oneOfCtx);
+    return yield* walkGen(merged, oneOfCtx);
   }
 
   if (anyOf) {
     // Try each branch until one works
     const branches = ctx.random.shuffle([...anyOf]);
-    
+
     for (const branch of branches) {
       const merged = mergeSchemas([base, branch]);
       try {
-        return await walk(merged, ctx);
+        return yield* walkGen(merged, ctx);
       } catch {
         // Try next branch
       }
@@ -116,32 +117,32 @@ export async function generateComposition(
     // If all fail, try the first one anyway
     const picked = anyOf[0];
     const merged = mergeSchemas([base, picked]);
-    return walk(merged, ctx);
+    return yield* walkGen(merged, ctx);
   }
 
   if (ifSchema !== undefined) {
-    return generateConditional(base, ifSchema, thenSchema, elseSchema, ctx);
+    return yield* generateConditionalGen(base, ifSchema, thenSchema, elseSchema, ctx);
   }
 
   if (not) {
-    return generateNot(base, not, ctx);
+    return yield* generateNotGen(base, not, ctx);
   }
 
-  return walk(base, ctx);
+  return yield* walkGen(base, ctx);
 }
 
-async function generateConditional(
+function* generateConditionalGen(
   base: JsonSchemaObject,
   ifSchema: JsonSchema,
   thenSchema: JsonSchema | undefined,
   elseSchema: JsonSchema | undefined,
   ctx: GenerateContext
-): Promise<unknown> {
+): Gen<unknown> {
   // Try the "if + then" branch first (preferred per JSON Schema semantics)
   if (thenSchema !== undefined) {
     const mergedIfThen = mergeSchemas([base, ifSchema, thenSchema]);
     try {
-      return await walk(mergedIfThen, ctx);
+      return yield* walkGen(mergedIfThen, ctx);
     } catch {
       // If then branch fails, fall through to try else
     }
@@ -151,28 +152,28 @@ async function generateConditional(
   if (elseSchema !== undefined) {
     const mergedElse = mergeSchemas([base, elseSchema]);
     try {
-      return await walk(mergedElse, ctx);
+      return yield* walkGen(mergedElse, ctx);
     } catch {
       // If else also fails, fall through
     }
   }
 
   // Fallback: just try base schema
-  return walk(base, ctx);
+  return yield* walkGen(base, ctx);
 }
 
-async function generateNot(
+function* generateNotGen(
   base: JsonSchemaObject,
   not: JsonSchema,
   ctx: GenerateContext
-): Promise<unknown> {
+): Gen<unknown> {
   if (typeof not === "boolean") {
     if (not === true) {
       // not true = nothing is valid — shouldn't happen
       throw new Error(`Cannot generate value for 'not: true' at ${ctx.path}`);
     }
     // not false = everything is valid
-    return walk(base, ctx);
+    return yield* walkGen(base, ctx);
   }
 
   // Simple type avoidance
@@ -184,7 +185,7 @@ async function generateNot(
     if (allowed.length > 0) {
       const type = ctx.random.pick(allowed);
       const merged = mergeSchemas([base, { type }]);
-      return walk(merged, ctx);
+      return yield* walkGen(merged, ctx);
     }
   }
 
@@ -194,7 +195,7 @@ async function generateNot(
     const excluded = not.enum ?? [not.const];
     const excludedSet = new Set(excluded.map((v) => JSON.stringify(v)));
     for (let i = 0; i < 20; i++) {
-      const value = await walk(base, ctx);
+      const value = yield* walkGen(base, ctx);
       if (!excludedSet.has(JSON.stringify(value))) {
         return value;
       }
@@ -202,5 +203,5 @@ async function generateNot(
   }
 
   // Fallback: generate from base
-  return walk(base, ctx);
+  return yield* walkGen(base, ctx);
 }

--- a/src/generators/jsonpath-resolver.ts
+++ b/src/generators/jsonpath-resolver.ts
@@ -52,12 +52,12 @@ function getInferredProperties(schema: JsonSchemaObject): Record<string, JsonSch
  * @param ctx - The generation context
  * @param rootValue - The root generated object (used for jsonPath resolution)
  */
-export async function resolveJsonPathsInValue(
+export function resolveJsonPathsInValue(
   value: unknown,
   schema: JsonSchema,
   ctx: GenerateContext,
   rootValue?: unknown
-): Promise<unknown> {
+): unknown {
   // If jsonPath resolution is not enabled, return as-is
   if (!ctx.resolveJsonPath) {
     return value;
@@ -113,13 +113,7 @@ export async function resolveJsonPathsInValue(
           }
         } else {
           // Recursively process nested objects, passing the root
-          const resolved = await resolveJsonPathsInValue(
-            propValue,
-            propSchema,
-            ctx,
-            root
-          );
-          result[key] = resolved;
+          result[key] = resolveJsonPathsInValue(propValue, propSchema, ctx, root);
         }
       }
     }
@@ -129,12 +123,7 @@ export async function resolveJsonPathsInValue(
 
   // Handle arrays
   if (Array.isArray(value) && objSchema.items) {
-    const results: unknown[] = [];
-    for (const item of value) {
-      const resolved = await resolveJsonPathsInValue(item, objSchema.items, ctx, root);
-      results.push(resolved);
-    }
-    return results;
+    return value.map((item) => resolveJsonPathsInValue(item, objSchema.items!, ctx, root));
   }
 
   return value;

--- a/src/generators/object.ts
+++ b/src/generators/object.ts
@@ -1,5 +1,6 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "../types.js";
-import { walk } from "../schema-walker.js";
+import { walkGen } from "../schema-walker.js";
+import { type Gen } from "../coroutine.js";
 import { mergeSchemas } from "../merge.js";
 import {
   createOptionalPropertySelector,
@@ -45,10 +46,10 @@ function isImpossibleSchema(schema: JsonSchema): boolean {
   return false;
 }
 
-export async function generateObject(
+export function* generateObjectGen(
   schema: JsonSchemaObject,
   ctx: GenerateContext
-): Promise<Record<string, unknown>> {
+): Gen<Record<string, unknown>> {
   // Get inferred properties if no explicit properties
   const inferredProperties = getInferredProperties(schema);
   const inferredRequired = getInferredRequired(schema, inferredProperties);
@@ -149,12 +150,12 @@ export async function generateObject(
       }
       
       if (isRequired) {
-        const value = await walk(mergedPropSchema, propCtx);
+        const value = yield* walkGen(mergedPropSchema, propCtx);
         if (value !== undefined) {
           result[key] = value;
         }
       } else if (shouldGenerateOptional(key)) {
-        const value = await walk(mergedPropSchema, propCtx);
+        const value = yield* walkGen(mergedPropSchema, propCtx);
         if (value !== undefined) {
           result[key] = value;
         }
@@ -166,7 +167,7 @@ export async function generateObject(
           for (const nestedKey of nestedRequired) {
             const nestedSchema = (propSchema.properties ?? {})[nestedKey] ?? {};
             const nestedCtx = createPropertyContext(propCtx, nestedKey);
-            const nestedValue = await walk(nestedSchema, nestedCtx);
+            const nestedValue = yield* walkGen(nestedSchema, nestedCtx);
             if (nestedValue !== undefined) {
               nestedResult[nestedKey] = nestedValue;
             }
@@ -195,7 +196,7 @@ export async function generateObject(
           ? matchingSchemas[0] 
           : mergeSchemas(matchingSchemas);
         const propCtx = createPropertyContext(childCtx, key);
-        const value = await walk(mergedSchema, propCtx);
+        const value = yield* walkGen(mergedSchema, propCtx);
         if (value !== undefined) {
           result[key] = value;
         }
@@ -206,7 +207,7 @@ export async function generateObject(
       const addlSchema = schema.additionalProperties ?? true;
       if (addlSchema !== false) {
         const propCtx = createPropertyContext(childCtx, key);
-        const value = await walk(addlSchema === true ? {} : addlSchema, propCtx);
+        const value = yield* walkGen(addlSchema === true ? {} : addlSchema, propCtx);
         if (value !== undefined) {
           result[key] = value;
         }
@@ -294,7 +295,7 @@ export async function generateObject(
             generatedByRequired.add(reqProp);
             const reqPropSchema = (matchingBranch.properties as Record<string, JsonSchema>)?.[reqProp] ?? { type: "object" };
             const reqPropCtx = createPropertyContext(childCtx, reqProp);
-            const value = await walk(reqPropSchema, reqPropCtx);
+            const value = yield* walkGen(reqPropSchema, reqPropCtx);
             if (value !== undefined) {
               result[reqProp] = value;
             }
@@ -310,7 +311,7 @@ export async function generateObject(
             if (generatedByRequired.has(depPropName)) continue;
             
             const depPropCtx = createPropertyContext(childCtx, depPropName);
-            const value = await walk(depPropSchema as JsonSchema, depPropCtx);
+            const value = yield* walkGen(depPropSchema as JsonSchema, depPropCtx);
             if (value !== undefined) {
               result[depPropName] = value;
             }
@@ -342,7 +343,7 @@ export async function generateObject(
         
         if (key && !result[key]) {
           const propCtx = createPropertyContext(childCtx, key);
-          const value = await walk(patSchema, propCtx);
+          const value = yield* walkGen(patSchema, propCtx);
           if (value !== undefined) {
             result[key] = value;
           }
@@ -364,7 +365,7 @@ export async function generateObject(
           const key = `prop${ctx.random.int(0, 99999)}`;
           if (!result[key]) {
             const propCtx = createPropertyContext(childCtx, key);
-            const value = await walk(genSchema, propCtx);
+            const value = yield* walkGen(genSchema, propCtx);
             if (value !== undefined) {
               result[key] = value;
             }

--- a/src/generators/object.ts
+++ b/src/generators/object.ts
@@ -1,6 +1,5 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "../types.js";
-import { walkGen } from "../schema-walker.js";
-import { type Gen } from "../coroutine.js";
+import { type Gen, walkCall } from "../coroutine.js";
 import { mergeSchemas } from "../merge.js";
 import {
   createOptionalPropertySelector,
@@ -150,12 +149,12 @@ export function* generateObjectGen(
       }
       
       if (isRequired) {
-        const value = yield* walkGen(mergedPropSchema, propCtx);
+        const value = yield walkCall(mergedPropSchema, propCtx);
         if (value !== undefined) {
           result[key] = value;
         }
       } else if (shouldGenerateOptional(key)) {
-        const value = yield* walkGen(mergedPropSchema, propCtx);
+        const value = yield walkCall(mergedPropSchema, propCtx);
         if (value !== undefined) {
           result[key] = value;
         }
@@ -167,7 +166,7 @@ export function* generateObjectGen(
           for (const nestedKey of nestedRequired) {
             const nestedSchema = (propSchema.properties ?? {})[nestedKey] ?? {};
             const nestedCtx = createPropertyContext(propCtx, nestedKey);
-            const nestedValue = yield* walkGen(nestedSchema, nestedCtx);
+            const nestedValue = yield walkCall(nestedSchema, nestedCtx);
             if (nestedValue !== undefined) {
               nestedResult[nestedKey] = nestedValue;
             }
@@ -196,7 +195,7 @@ export function* generateObjectGen(
           ? matchingSchemas[0] 
           : mergeSchemas(matchingSchemas);
         const propCtx = createPropertyContext(childCtx, key);
-        const value = yield* walkGen(mergedSchema, propCtx);
+        const value = yield walkCall(mergedSchema, propCtx);
         if (value !== undefined) {
           result[key] = value;
         }
@@ -207,7 +206,7 @@ export function* generateObjectGen(
       const addlSchema = schema.additionalProperties ?? true;
       if (addlSchema !== false) {
         const propCtx = createPropertyContext(childCtx, key);
-        const value = yield* walkGen(addlSchema === true ? {} : addlSchema, propCtx);
+        const value = yield walkCall(addlSchema === true ? {} : addlSchema, propCtx);
         if (value !== undefined) {
           result[key] = value;
         }
@@ -295,7 +294,7 @@ export function* generateObjectGen(
             generatedByRequired.add(reqProp);
             const reqPropSchema = (matchingBranch.properties as Record<string, JsonSchema>)?.[reqProp] ?? { type: "object" };
             const reqPropCtx = createPropertyContext(childCtx, reqProp);
-            const value = yield* walkGen(reqPropSchema, reqPropCtx);
+            const value = yield walkCall(reqPropSchema, reqPropCtx);
             if (value !== undefined) {
               result[reqProp] = value;
             }
@@ -311,7 +310,7 @@ export function* generateObjectGen(
             if (generatedByRequired.has(depPropName)) continue;
             
             const depPropCtx = createPropertyContext(childCtx, depPropName);
-            const value = yield* walkGen(depPropSchema as JsonSchema, depPropCtx);
+            const value = yield walkCall(depPropSchema as JsonSchema, depPropCtx);
             if (value !== undefined) {
               result[depPropName] = value;
             }
@@ -343,7 +342,7 @@ export function* generateObjectGen(
         
         if (key && !result[key]) {
           const propCtx = createPropertyContext(childCtx, key);
-          const value = yield* walkGen(patSchema, propCtx);
+          const value = yield walkCall(patSchema, propCtx);
           if (value !== undefined) {
             result[key] = value;
           }
@@ -365,7 +364,7 @@ export function* generateObjectGen(
           const key = `prop${ctx.random.int(0, 99999)}`;
           if (!result[key]) {
             const propCtx = createPropertyContext(childCtx, key);
-            const value = yield* walkGen(genSchema, propCtx);
+            const value = yield walkCall(genSchema, propCtx);
             if (value !== undefined) {
               result[key] = value;
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
-import type { JsonSchema, JsonSchemaObject, GenerateOptions, GenerateContext, Random, RefResolver } from "./types.js";
+import type { JsonSchema, JsonSchemaObject, GenerateOptions, GenerateSyncOptions, GenerateContext, Random, RefResolver } from "./types.js";
 import { createRandom } from "./random.js";
-import { walk } from "./schema-walker.js";
+import { walk, walkSync } from "./schema-walker.js";
 import { buildRefRegistry, registerRootSchema } from "./ref-resolver.js";
 import { createFormatRegistry, registerFormatGlobal } from "./formats/index.js";
 import { createRemoteResolver, type RemoteResolverOptions } from "./remote-resolver.js";
 import { resolveJsonPathsInValue } from "./generators/jsonpath-resolver.js";
 import { registerExtension, resetExtension, type ExtensionCallback } from "./extensions.js";
 
-export type { JsonSchema, GenerateOptions, Random, RefResolver } from "./types.js";
+export type { JsonSchema, GenerateOptions, GenerateSyncOptions, Random, RefResolver } from "./types.js";
 export { createRemoteResolver, type RemoteResolverOptions } from "./remote-resolver.js";
 export type { ExtensionCallback } from "./extensions.js";
 
@@ -20,7 +20,18 @@ const SUPPORTED_SCHEMA_VERSIONS = new Set([
   "https://json-schema.org/draft/2019-09/schema"
 ]);
 
-export async function generate(schema: JsonSchema, options?: GenerateOptions): Promise<unknown> {
+interface BuiltContext {
+  schema_: JsonSchema;
+  normalizedOptions: GenerateOptions;
+  ctx: GenerateContext;
+}
+
+/**
+ * Validate options and construct the schema-to-generate plus the GenerateContext.
+ * Shared by generate() and generateSync() — each sets its own delta fields afterward
+ * (refResolver for the async path, __sync for the sync path).
+ */
+function buildContext(schema: JsonSchema, options?: GenerateOptions): BuiltContext {
   // Validate $schema if present (opt-in via validateSchemaVersion option, defaults to false)
   // Skip when propAliases is set — the user is explicitly opting into compat mode for older drafts
   if (options?.validateSchemaVersion === true && !options?.propAliases) {
@@ -58,7 +69,6 @@ export async function generate(schema: JsonSchema, options?: GenerateOptions): P
     refRegistry,
     refStack: new Set(),
     formatRegistry,
-    refResolver: normalizedOptions.refResolver,
     minItems: normalizedOptions.minItems,
     maxItems: normalizedOptions.maxItems,
     minLength: normalizedOptions.minLength,
@@ -86,6 +96,13 @@ export async function generate(schema: JsonSchema, options?: GenerateOptions): P
     outputTransform: normalizedOptions.outputTransform,
   };
 
+  return { schema_, normalizedOptions, ctx };
+}
+
+export async function generate(schema: JsonSchema, options?: GenerateOptions): Promise<unknown> {
+  const { schema_, normalizedOptions, ctx } = buildContext(schema, options);
+  ctx.refResolver = normalizedOptions.refResolver;
+
   const result = await walk(schema_, ctx);
 
   // Post-process to resolve jsonPath references if enabled
@@ -104,6 +121,35 @@ export function createGenerator(options?: GenerateOptions) {
     generate(schema: JsonSchema): Promise<unknown> {
       const seed = (baseOptions.seed ?? 1) + callCount++;
       return generate(schema, { ...baseOptions, seed });
+    },
+  };
+}
+
+export function generateSync(schema: JsonSchema, options?: GenerateSyncOptions): unknown {
+  if ((options as GenerateOptions | undefined)?.refResolver) {
+    throw new Error("generateSync() cannot use refResolver; pre-resolve remote refs before calling generateSync()");
+  }
+
+  const { schema_, normalizedOptions, ctx } = buildContext(schema, options);
+  ctx.__sync = true;
+
+  const result = walkSync(schema_, ctx);
+
+  if (normalizedOptions.resolveJsonPath) {
+    return resolveJsonPathsInValue(result, schema, ctx, result);
+  }
+
+  return result;
+}
+
+export function createGeneratorSync(options?: GenerateSyncOptions) {
+  const baseOptions = { ...options };
+  let callCount = 0;
+
+  return {
+    generate(schema: JsonSchema): unknown {
+      const seed = (baseOptions.seed ?? 1) + callCount++;
+      return generateSync(schema, { ...baseOptions, seed });
     },
   };
 }
@@ -236,8 +282,11 @@ function composeOutputTransforms(
     return base;
   }
 
-  return async (value, schema, path) => {
-    const transformed = await base(value, schema, path);
+  return (value, schema, path) => {
+    const transformed = base(value, schema, path);
+    if (transformed && typeof transformed === "object" && "then" in transformed && typeof transformed.then === "function") {
+      return transformed.then((resolved: unknown) => next(resolved, schema, path));
+    }
     return next(transformed, schema, path);
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,12 +126,9 @@ export function createGenerator(options?: GenerateOptions) {
 }
 
 export function generateSync(schema: JsonSchema, options?: GenerateSyncOptions): unknown {
-  if ((options as GenerateOptions | undefined)?.refResolver) {
-    throw new Error("generateSync() cannot use refResolver; pre-resolve remote refs before calling generateSync()");
-  }
-
   const { schema_, normalizedOptions, ctx } = buildContext(schema, options);
   ctx.__sync = true;
+  ctx.refResolver = normalizedOptions.refResolver;
 
   const result = walkSync(schema_, ctx);
 

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -1,5 +1,6 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "./types.js";
 import { resolveFragment } from "./remote-resolver.js";
+import { type Gen } from "./coroutine.js";
 
 export function buildRefRegistry(schema: JsonSchema): Map<string, JsonSchema> {
   const registry = new Map<string, JsonSchema>();
@@ -29,10 +30,10 @@ export interface ResolvedRef {
   ctx: GenerateContext;
 }
 
-export async function resolveRef(
+export function* resolveRefGen(
   schema: JsonSchemaObject,
   ctx: GenerateContext
-): Promise<ResolvedRef> {
+): Gen<ResolvedRef> {
   const ref = schema.$ref;
   if (!ref) return { schema, ctx };
 
@@ -75,7 +76,7 @@ export async function resolveRef(
     }
     // If still not found, try refResolver (e.g. for OpenAPI-style #/components/schemas/... refs)
     if (resolved === undefined && ctx.refResolver) {
-      resolved = await ctx.refResolver(ref);
+      resolved = (yield ctx.refResolver(ref)) as JsonSchema;
       if (resolved !== undefined) {
         ctx.refRegistry.set(ref, resolved);
       }
@@ -88,7 +89,7 @@ export async function resolveRef(
 
     // If not in registry and we have a refResolver, try that
     if (resolved === undefined && ctx.refResolver) {
-      baseSchema = await ctx.refResolver(ref);
+      baseSchema = (yield ctx.refResolver(ref)) as JsonSchema;
 
       // Extract the fragment from the full schema if the ref has a fragment
       const hashIndex = ref.indexOf("#");
@@ -112,6 +113,10 @@ export async function resolveRef(
           }
         }
       }
+    } else if (resolved === undefined && ctx.__sync) {
+      // Sync mode can't fetch remote refs — give a precise, actionable error
+      // instead of falling through to the generic "Unresolved $ref" below.
+      throw new Error(`Remote $ref '${ref}' cannot be resolved in generateSync(); pre-resolve refs or use generate()`);
     }
   }
 

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -1,6 +1,14 @@
 import type { JsonSchema, JsonSchemaObject, GenerateContext } from "./types.js";
 import { resolveFragment } from "./remote-resolver.js";
-import { type Gen } from "./coroutine.js";
+import { type Gen, isPromiseLike } from "./coroutine.js";
+
+function* callRefResolverGen(ref: string, ctx: GenerateContext): Gen<JsonSchema> {
+  const raw = ctx.refResolver!(ref);
+  if (ctx.__sync && isPromiseLike(raw)) {
+    throw new Error(`Cannot use async refResolver in generateSync(): resolving '${ref}' returned a Promise`);
+  }
+  return (yield raw) as JsonSchema;
+}
 
 export function buildRefRegistry(schema: JsonSchema): Map<string, JsonSchema> {
   const registry = new Map<string, JsonSchema>();
@@ -76,7 +84,7 @@ export function* resolveRefGen(
     }
     // If still not found, try refResolver (e.g. for OpenAPI-style #/components/schemas/... refs)
     if (resolved === undefined && ctx.refResolver) {
-      resolved = (yield ctx.refResolver(ref)) as JsonSchema;
+      resolved = yield* callRefResolverGen(ref, ctx);
       if (resolved !== undefined) {
         ctx.refRegistry.set(ref, resolved);
       }
@@ -89,7 +97,7 @@ export function* resolveRefGen(
 
     // If not in registry and we have a refResolver, try that
     if (resolved === undefined && ctx.refResolver) {
-      baseSchema = (yield ctx.refResolver(ref)) as JsonSchema;
+      baseSchema = yield* callRefResolverGen(ref, ctx);
 
       // Extract the fragment from the full schema if the ref has a fragment
       const hashIndex = ref.indexOf("#");

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -5,6 +5,9 @@ import { type Gen, isPromiseLike } from "./coroutine.js";
 function* callRefResolverGen(ref: string, ctx: GenerateContext): Gen<JsonSchema> {
   const raw = ctx.refResolver!(ref);
   if (ctx.__sync && isPromiseLike(raw)) {
+    // Swallow the rejection so it doesn't surface as an unhandled promise
+    // rejection after we throw synchronously below.
+    Promise.resolve(raw).catch(() => {});
     throw new Error(`Cannot use async refResolver in generateSync(): resolving '${ref}' returned a Promise`);
   }
   return (yield raw) as JsonSchema;

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -200,6 +200,9 @@ function* applyOutputTransformGen(value: unknown, schema: JsonSchema, ctx: Gener
   }
   const raw = ctx.outputTransform(value, schema, ctx.outputPath);
   if (ctx.__sync && isPromiseLike(raw)) {
+    // Swallow the rejection so it doesn't surface as an unhandled promise
+    // rejection after we throw synchronously below.
+    Promise.resolve(raw).catch(() => {});
     throw new Error("Cannot use async outputTransform in generateSync()");
   }
   return yield raw;

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -5,14 +5,15 @@ import { generateNumber } from "./generators/number.js";
 import { generateInteger } from "./generators/integer.js";
 import { generateString } from "./generators/string.js";
 import { generateEnumConst } from "./generators/enum-const.js";
-import { generateObject } from "./generators/object.js";
-import { generateArray } from "./generators/array.js";
-import { generateComposition } from "./generators/composition.js";
-import { resolveRef } from "./ref-resolver.js";
+import { generateObjectGen } from "./generators/object.js";
+import { generateArrayGen } from "./generators/array.js";
+import { generateCompositionGen } from "./generators/composition.js";
+import { resolveRefGen } from "./ref-resolver.js";
 import { SCHEMA_KEYWORDS } from "./utils/schema-keywords.js";
 import { pad2 } from "./utils/helpers.js";
 import { filterExampleDefaultValue } from "./utils/optional-properties.js";
-import { generateFromExtensions } from "./extensions.js";
+import { generateFromExtensionsGen } from "./extensions.js";
+import { type Gen, isPromiseLike, runAsync, runSync } from "./coroutine.js";
 
 const ALL_TYPES = ["string", "number", "integer", "boolean", "null", "object", "array"] as const;
 
@@ -193,17 +194,21 @@ function childContext(ctx: GenerateContext, segment: string): GenerateContext {
   };
 }
 
-async function applyOutputTransform(value: unknown, schema: JsonSchema, ctx: GenerateContext): Promise<unknown> {
+function* applyOutputTransformGen(value: unknown, schema: JsonSchema, ctx: GenerateContext): Gen<unknown> {
   if (!ctx.outputTransform) {
     return value;
   }
-  return ctx.outputTransform(value, schema, ctx.outputPath);
+  const raw = ctx.outputTransform(value, schema, ctx.outputPath);
+  if (ctx.__sync && isPromiseLike(raw)) {
+    throw new Error("Cannot use async outputTransform in generateSync()");
+  }
+  return yield raw;
 }
 
-export async function walk(schema: JsonSchema, ctx: GenerateContext): Promise<unknown> {
+export function* walkGen(schema: JsonSchema, ctx: GenerateContext): Gen<unknown> {
   // Boolean schemas
   if (schema === true) {
-    return walk({}, ctx);
+    return yield* walkGen({}, ctx);
   }
   if (schema === false) {
     throw new Error(`Cannot generate value for 'false' schema at ${ctx.path}`);
@@ -225,7 +230,7 @@ export async function walk(schema: JsonSchema, ctx: GenerateContext): Promise<un
   }
 
   try {
-    return await walkSchemaBody(schema as JsonSchemaObject, ctx);
+    return yield* walkSchemaBodyGen(schema as JsonSchemaObject, ctx);
   } finally {
     // Restore previous $defs entries so each schema document gets
     // local scoping — root-registered $defs still take precedence.
@@ -241,7 +246,7 @@ export async function walk(schema: JsonSchema, ctx: GenerateContext): Promise<un
   }
 }
 
-async function walkSchemaBody(schema: JsonSchemaObject, ctx: GenerateContext): Promise<unknown> {
+function* walkSchemaBodyGen(schema: JsonSchemaObject, ctx: GenerateContext): Gen<unknown> {
   // Apply propAliases: remap custom schema keys to known ones before processing
   if (ctx.propAliases) {
     let patched: JsonSchemaObject | null = null;
@@ -274,65 +279,65 @@ async function walkSchemaBody(schema: JsonSchemaObject, ctx: GenerateContext): P
     if (extResult !== undefined) {
       // Apply string truncation if result is a string and maxLength is set
       if (typeof extResult === "string" && extCtx.maxLength !== undefined && extResult.length > extCtx.maxLength) {
-        return applyOutputTransform(extResult.slice(0, extCtx.maxLength), schema, extCtx);
+        return yield* applyOutputTransformGen(extResult.slice(0, extCtx.maxLength), schema, extCtx);
       }
-      return applyOutputTransform(extResult, schema, extCtx);
+      return yield* applyOutputTransformGen(extResult, schema, extCtx);
     }
   } else {
     const extResult = generateFromExtension(schema, ctx, resolvedType);
     if (extResult !== undefined) {
       // Apply string truncation if result is a string and maxLength is set
       if (typeof extResult === "string" && ctx.maxLength !== undefined && extResult.length > ctx.maxLength) {
-        return applyOutputTransform(extResult.slice(0, ctx.maxLength), schema, ctx);
+        return yield* applyOutputTransformGen(extResult.slice(0, ctx.maxLength), schema, ctx);
       }
-      return applyOutputTransform(extResult, schema, ctx);
+      return yield* applyOutputTransformGen(extResult, schema, ctx);
     }
   }
 
   // Custom keyword extensions (jsf.define)
   const extCtx: GenerateContext = {
     ...ctx,
-    proceed: (subSchema, overrides) => walk(subSchema, { ...ctx, ...overrides }),
+    proceed: (subSchema, overrides) => (ctx.__sync ? walkSync : walk)(subSchema, { ...ctx, ...overrides }),
   };
-  const customExtResult = await generateFromExtensions(schema, extCtx);
+  const customExtResult = yield* generateFromExtensionsGen(schema, extCtx);
   if (customExtResult !== undefined) {
-    return applyOutputTransform(customExtResult, schema, extCtx);
+    return yield* applyOutputTransformGen(customExtResult, schema, extCtx);
   }
 
   // $ref resolution
   if (schema.$ref) {
-    const resolved = await resolveRef(schema, ctx);
-    return walk(resolved.schema, childContext(resolved.ctx, "$ref"));
+    const resolved = yield* resolveRefGen(schema, ctx);
+    return yield* walkGen(resolved.schema, childContext(resolved.ctx, "$ref"));
   }
 
   // Composition keywords
   if (schema.allOf || schema.anyOf || schema.oneOf || schema.not || schema.if) {
-    return generateComposition(schema, ctx);
+    return yield* generateCompositionGen(schema, ctx);
   }
 
   // const
   if (schema.const !== undefined) {
-    return applyOutputTransform(generateEnumConst(schema, ctx), schema, ctx);
+    return yield* applyOutputTransformGen(generateEnumConst(schema, ctx), schema, ctx);
   }
 
   // default value (when useDefaultValue option is enabled)
   if (ctx.useDefaultValue && schema.default !== undefined) {
-    return applyOutputTransform(filterExampleDefaultValue(schema.default, schema, ctx), schema, ctx);
+    return yield* applyOutputTransformGen(filterExampleDefaultValue(schema.default, schema, ctx), schema, ctx);
   }
 
   // enum
   if (schema.enum !== undefined) {
-    return applyOutputTransform(generateEnumConst(schema, ctx), schema, ctx);
+    return yield* applyOutputTransformGen(generateEnumConst(schema, ctx), schema, ctx);
   }
 
   // examples value (when useExamplesValue option is enabled)
   if (ctx.useExamplesValue) {
     if (Array.isArray(schema.examples) && schema.examples.length > 0) {
       const picked = ctx.random.pick(schema.examples);
-      return applyOutputTransform(filterExampleDefaultValue(picked, schema, ctx), schema, ctx);
+      return yield* applyOutputTransformGen(filterExampleDefaultValue(picked, schema, ctx), schema, ctx);
     }
     if (schema.example !== undefined) {
-      return applyOutputTransform(filterExampleDefaultValue(schema.example, schema, ctx), schema, ctx);
+      return yield* applyOutputTransformGen(filterExampleDefaultValue(schema.example, schema, ctx), schema, ctx);
     }
   }
 
@@ -345,7 +350,7 @@ async function walkSchemaBody(schema: JsonSchemaObject, ctx: GenerateContext): P
       if (ctx.defaultInvalidTypeProduct !== undefined) {
         const defaultProduct = ctx.defaultInvalidTypeProduct;
         if (typeof defaultProduct === "string") {
-          return handleDefaultInvalidTypeProduct(defaultProduct, ctx);
+          return handleDefaultInvalidTypeProduct(defaultProduct);
         }
         return defaultProduct;
       }
@@ -357,19 +362,19 @@ async function walkSchemaBody(schema: JsonSchemaObject, ctx: GenerateContext): P
 
   switch (type) {
     case "null":
-      return applyOutputTransform(generateNull(ctx), schema, ctx);
+      return yield* applyOutputTransformGen(generateNull(ctx), schema, ctx);
     case "boolean":
-      return applyOutputTransform(generateBoolean(ctx), schema, ctx);
+      return yield* applyOutputTransformGen(generateBoolean(ctx), schema, ctx);
     case "number":
-      return applyOutputTransform(generateNumber(schema, ctx), schema, ctx);
+      return yield* applyOutputTransformGen(generateNumber(schema, ctx), schema, ctx);
     case "integer":
-      return applyOutputTransform(generateInteger(schema, ctx), schema, ctx);
+      return yield* applyOutputTransformGen(generateInteger(schema, ctx), schema, ctx);
     case "string":
-      return applyOutputTransform(generateString(schema, ctx), schema, ctx);
+      return yield* applyOutputTransformGen(generateString(schema, ctx), schema, ctx);
     case "object":
-      return applyOutputTransform(await generateObject(schema, ctx), schema, ctx);
+      return yield* applyOutputTransformGen(yield* generateObjectGen(schema, ctx), schema, ctx);
     case "array":
-      return applyOutputTransform(await generateArray(schema, ctx), schema, ctx);
+      return yield* applyOutputTransformGen(yield* generateArrayGen(schema, ctx), schema, ctx);
     default:
       throw new Error(`Unknown type: ${type} at ${ctx.path}`);
   }
@@ -440,7 +445,7 @@ function hasInferredProperties(schema: JsonSchemaObject): boolean {
   return false;
 }
 
-function handleDefaultInvalidTypeProduct(typeName: string, ctx: GenerateContext): unknown {
+function handleDefaultInvalidTypeProduct(typeName: string): unknown {
   switch (typeName) {
     case "string":
       return "";
@@ -458,4 +463,12 @@ function handleDefaultInvalidTypeProduct(typeName: string, ctx: GenerateContext)
     default:
       return null;
   }
+}
+
+export function walk(schema: JsonSchema, ctx: GenerateContext): Promise<unknown> {
+  return runAsync(walkGen(schema, ctx));
+}
+
+export function walkSync(schema: JsonSchema, ctx: GenerateContext): unknown {
+  return runSync(walkGen(schema, ctx));
 }

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -13,7 +13,7 @@ import { SCHEMA_KEYWORDS } from "./utils/schema-keywords.js";
 import { pad2 } from "./utils/helpers.js";
 import { filterExampleDefaultValue } from "./utils/optional-properties.js";
 import { generateFromExtensionsGen } from "./extensions.js";
-import { type Gen, isPromiseLike, runAsync, runSync } from "./coroutine.js";
+import { type Gen, isPromiseLike, runAsync, runSync, walkCall } from "./coroutine.js";
 
 const ALL_TYPES = ["string", "number", "integer", "boolean", "null", "object", "array"] as const;
 
@@ -310,7 +310,7 @@ function* walkSchemaBodyGen(schema: JsonSchemaObject, ctx: GenerateContext): Gen
   // $ref resolution
   if (schema.$ref) {
     const resolved = yield* resolveRefGen(schema, ctx);
-    return yield* walkGen(resolved.schema, childContext(resolved.ctx, "$ref"));
+    return yield walkCall(resolved.schema, childContext(resolved.ctx, "$ref"));
   }
 
   // Composition keywords
@@ -469,9 +469,9 @@ function handleDefaultInvalidTypeProduct(typeName: string): unknown {
 }
 
 export function walk(schema: JsonSchema, ctx: GenerateContext): Promise<unknown> {
-  return runAsync(walkGen(schema, ctx));
+  return runAsync(walkGen(schema, ctx), walkGen);
 }
 
 export function walkSync(schema: JsonSchema, ctx: GenerateContext): unknown {
-  return runSync(walkGen(schema, ctx));
+  return runSync(walkGen(schema, ctx), walkGen);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,9 +150,7 @@ export interface GenerateOptions {
   };
 }
 
-export interface GenerateSyncOptions extends Omit<GenerateOptions, "refResolver"> {
-  refResolver?: never;
-}
+export type GenerateSyncOptions = GenerateOptions;
 
 export interface GenerateContext {
   random: Random;

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,10 @@ export interface GenerateOptions {
   };
 }
 
+export interface GenerateSyncOptions extends Omit<GenerateOptions, "refResolver"> {
+  refResolver?: never;
+}
+
 export interface GenerateContext {
   random: Random;
   maxDepth: number;
@@ -218,7 +222,9 @@ export interface GenerateContext {
   /** Transform generated output values using the final output-tree JSON pointer path */
   outputTransform?: (value: unknown, schema: JsonSchema, path: string) => unknown | Promise<unknown>;
   /** Generate a value from a subschema using the current generation context */
-  proceed?: (schema: JsonSchema, overrides?: Partial<GenerateContext>) => Promise<unknown>;
+  proceed?: (schema: JsonSchema, overrides?: Partial<GenerateContext>) => unknown | Promise<unknown>;
+  /** @internal set by generateSync()'s driver only; used to produce precise sync-only error messages */
+  __sync?: boolean;
 }
 
 export interface Random {

--- a/tests/unit/deep-recursion.test.ts
+++ b/tests/unit/deep-recursion.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "bun:test";
+import { generate, generateSync, type JsonSchema } from "../../src/index.js";
+
+// Regression test for a stack overflow found in review of #879: walkGen()
+// used to recurse via native `yield*` delegation, so a deep $ref chain (or
+// deeply nested required-property tree) grew the JS call stack one frame per
+// schema level and threw "RangeError: Maximum call stack size exceeded" well
+// before reaching refDepthMax. The fix routes recursive schema walks through
+// an explicit-stack trampoline (see WalkCall in src/coroutine.ts) instead of
+// yield* delegation, so call-stack depth stays flat regardless of schema
+// recursion depth.
+describe("deep recursion (stack safety)", () => {
+  const selfRefSchema: JsonSchema = {
+    type: "object",
+    required: ["child"],
+    properties: {
+      child: { $ref: "#" },
+      val: { type: "integer" },
+    },
+  };
+
+  test("generate() resolves a deep self-referencing $ref chain without a stack overflow", async () => {
+    const result = await generate(selfRefSchema, { refDepthMax: 5000, maxDepth: 5100, seed: 1 });
+    let depth = 0;
+    let node: any = result;
+    while (node && typeof node === "object" && "child" in node) {
+      depth++;
+      node = node.child;
+    }
+    expect(depth).toBeGreaterThan(1000);
+  });
+
+  test("generateSync() resolves a deep self-referencing $ref chain without a stack overflow", () => {
+    const result = generateSync(selfRefSchema, { refDepthMax: 5000, maxDepth: 5100, seed: 1 });
+    let depth = 0;
+    let node: any = result;
+    while (node && typeof node === "object" && "child" in node) {
+      depth++;
+      node = node.child;
+    }
+    expect(depth).toBeGreaterThan(1000);
+  });
+
+  function buildNestedRequiredSchema(depth: number): JsonSchema {
+    let schema: JsonSchema = { type: "integer", const: 0 };
+    for (let i = 0; i < depth; i++) {
+      schema = {
+        type: "object",
+        required: ["next"],
+        properties: { next: schema },
+      };
+    }
+    return schema;
+  }
+
+  test("generate() resolves a deeply nested required-property tree (no $ref) without a stack overflow", async () => {
+    const schema = buildNestedRequiredSchema(6000);
+    const result = await generate(schema, { seed: 1, maxDepth: 6001 }) as Record<string, unknown>;
+    let depth = 0;
+    let node: any = result;
+    while (node && typeof node === "object" && "next" in node) {
+      depth++;
+      node = node.next;
+    }
+    expect(depth).toBe(6000);
+    expect(node).toBe(0);
+  });
+
+  test("generateSync() resolves a deeply nested required-property tree (no $ref) without a stack overflow", () => {
+    const schema = buildNestedRequiredSchema(6000);
+    const result = generateSync(schema, { seed: 1, maxDepth: 6001 }) as Record<string, unknown>;
+    let depth = 0;
+    let node: any = result;
+    while (node && typeof node === "object" && "next" in node) {
+      depth++;
+      node = node.next;
+    }
+    expect(depth).toBe(6000);
+    expect(node).toBe(0);
+  });
+});

--- a/tests/unit/sync-async-parity.test.ts
+++ b/tests/unit/sync-async-parity.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect } from "bun:test";
+import { generate, generateSync, type JsonSchema } from "../../src/index.js";
+
+// Both generate() and generateSync() drive the exact same generator core
+// (see src/schema-walker.ts's walkGen). For any schema that never touches
+// ctx.refResolver, an async jsf.define() callback, or an async outputTransform,
+// the two drivers must produce byte-identical output for the same seed —
+// any divergence here means the sync/async paths have drifted apart again.
+const SCHEMAS: Array<{ name: string; schema: JsonSchema }> = [
+  {
+    name: "object with required + optional",
+    schema: {
+      type: "object",
+      required: ["id", "name"],
+      properties: {
+        id: { type: "integer", minimum: 1, maximum: 1000 },
+        name: { type: "string", minLength: 3, maxLength: 12 },
+        nickname: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "nested objects",
+    schema: {
+      type: "object",
+      required: ["user"],
+      properties: {
+        user: {
+          type: "object",
+          required: ["profile"],
+          properties: {
+            profile: {
+              type: "object",
+              required: ["age"],
+              properties: { age: { type: "integer", minimum: 0, maximum: 99 } },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    name: "array with items",
+    schema: { type: "array", items: { type: "string" }, minItems: 2, maxItems: 5 },
+  },
+  {
+    name: "array with prefixItems + contains + uniqueItems",
+    schema: {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "integer" }],
+      items: { type: "boolean" },
+      contains: { const: "must-have" },
+      uniqueItems: true,
+      minItems: 4,
+      maxItems: 8,
+    },
+  },
+  {
+    name: "allOf",
+    schema: {
+      allOf: [
+        { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+        { type: "object", properties: { b: { type: "integer" } }, required: ["b"] },
+      ],
+    },
+  },
+  {
+    name: "oneOf",
+    schema: {
+      oneOf: [
+        { type: "object", properties: { kind: { const: "cat" }, meow: { type: "boolean" } }, required: ["kind", "meow"] },
+        { type: "object", properties: { kind: { const: "dog" }, bark: { type: "boolean" } }, required: ["kind", "bark"] },
+      ],
+    },
+  },
+  {
+    name: "anyOf",
+    schema: { anyOf: [{ type: "string" }, { type: "integer" }] },
+  },
+  {
+    name: "if/then/else",
+    schema: {
+      type: "object",
+      properties: { isMember: { type: "boolean" } },
+      required: ["isMember"],
+      if: { properties: { isMember: { const: true } } },
+      then: { properties: { discount: { type: "integer", minimum: 5, maximum: 20 } }, required: ["discount"] },
+      else: { properties: { discount: { const: 0 } }, required: ["discount"] },
+    },
+  },
+  {
+    name: "not",
+    schema: { not: { type: "string" } },
+  },
+  {
+    name: "enum/const",
+    schema: {
+      type: "object",
+      properties: { status: { enum: ["active", "inactive", "pending"] }, kind: { const: "fixed" } },
+      required: ["status", "kind"],
+    },
+  },
+  {
+    name: "local $ref + $defs",
+    schema: {
+      type: "object",
+      required: ["user"],
+      properties: { user: { $ref: "#/$defs/user" } },
+      $defs: {
+        user: {
+          type: "object",
+          required: ["name"],
+          properties: { name: { type: "string" } },
+        },
+      },
+    },
+  },
+  {
+    name: "patternProperties",
+    schema: {
+      type: "object",
+      patternProperties: { "^hyb$": { type: "string" } },
+      additionalProperties: false,
+      minProperties: 1,
+    },
+  },
+  {
+    name: "dependencies",
+    schema: {
+      type: "object",
+      properties: { credit_card: { type: "string" } },
+      dependencies: {
+        credit_card: { properties: { billing_address: { type: "string" } }, required: ["billing_address"] },
+      },
+      required: ["credit_card"],
+    },
+  },
+  {
+    name: "pruneProperties source",
+    schema: {
+      type: "object",
+      required: ["keep", "drop"],
+      properties: { keep: { type: "string" }, drop: { type: "string" } },
+    },
+  },
+];
+
+describe("generate()/generateSync() parity", () => {
+  for (const { name, schema } of SCHEMAS) {
+    for (const seed of [1, 2, 3, 42, 12345]) {
+      test(`identical output for seed=${seed}: ${name}`, async () => {
+        const asyncResult = await generate(schema, { seed });
+        const syncResult = generateSync(schema, { seed });
+        expect(syncResult).toEqual(asyncResult);
+      });
+    }
+  }
+
+  test("propAliases: identical output for seed=1", async () => {
+    const schema = {
+      definitions: { myNumber: { type: "number", minimum: 0, maximum: 100 } },
+      type: "object",
+      required: ["refd"],
+      properties: { refd: { $ref: "#/$defs/myNumber" } },
+    } as unknown as JsonSchema;
+    const options = { seed: 1, propAliases: { definitions: "$defs" } };
+    const asyncResult = await generate(schema, options);
+    const syncResult = generateSync(schema, options);
+    expect(syncResult).toEqual(asyncResult);
+  });
+
+  test("pruneProperties: identical output for seed=1", async () => {
+    const schema: JsonSchema = {
+      type: "object",
+      required: ["keep", "drop"],
+      properties: { keep: { type: "string" }, drop: { type: "string" } },
+    };
+    const options = { seed: 1, pruneProperties: ["drop"] };
+    const asyncResult = await generate(schema, options);
+    const syncResult = generateSync(schema, options);
+    expect(syncResult).toEqual(asyncResult);
+  });
+});

--- a/tests/unit/sync.test.ts
+++ b/tests/unit/sync.test.ts
@@ -47,11 +47,20 @@ describe("generateSync", () => {
     );
   });
 
-  test("throws when refResolver is provided", () => {
+  test("resolves refs synchronously via a sync refResolver", () => {
+    const result = generateSync(
+      { $ref: "external" },
+      { refResolver: () => ({ type: "string", const: "resolved" }) }
+    );
+
+    expect(result).toBe("resolved");
+  });
+
+  test("throws when refResolver returns a Promise", () => {
     expect(() => generateSync(
       { $ref: "external" },
-      { refResolver: () => ({ type: "string" }) } as never
-    )).toThrow("generateSync() cannot use refResolver");
+      { refResolver: () => Promise.resolve({ type: "string" }) }
+    )).toThrow("Cannot use async refResolver in generateSync()");
   });
 
   test("throws for async extensions", () => {

--- a/tests/unit/sync.test.ts
+++ b/tests/unit/sync.test.ts
@@ -1,0 +1,107 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { generateSync, createGeneratorSync, define, reset } from "../../src/index.js";
+
+describe("generateSync", () => {
+  afterEach(() => {
+    reset();
+  });
+
+  test("generates values synchronously", () => {
+    const result = generateSync({
+      type: "object",
+      required: ["id", "name"],
+      properties: {
+        id: { type: "integer", minimum: 1, maximum: 10 },
+        name: { type: "string", minLength: 3 },
+      },
+    }, { seed: 1 }) as Record<string, unknown>;
+
+    expect(typeof result.id).toBe("number");
+    expect(typeof result.name).toBe("string");
+  });
+
+  test("resolves local refs synchronously", () => {
+    const result = generateSync({
+      type: "object",
+      required: ["user"],
+      properties: {
+        user: { $ref: "#/$defs/user" },
+      },
+      $defs: {
+        user: {
+          type: "object",
+          required: ["name"],
+          properties: {
+            name: { const: "Ada" },
+          },
+        },
+      },
+    }) as { user: { name: string } };
+
+    expect(result.user.name).toBe("Ada");
+  });
+
+  test("throws for remote refs", () => {
+    expect(() => generateSync({ $ref: "https://example.com/schema.json" })).toThrow(
+      "Remote $ref 'https://example.com/schema.json' cannot be resolved in generateSync()"
+    );
+  });
+
+  test("throws when refResolver is provided", () => {
+    expect(() => generateSync(
+      { $ref: "external" },
+      { refResolver: () => ({ type: "string" }) } as never
+    )).toThrow("generateSync() cannot use refResolver");
+  });
+
+  test("throws for async extensions", () => {
+    define("asyncValue", async function () {
+      return "value";
+    });
+
+    expect(() => generateSync({ type: "string", asyncValue: true })).toThrow(
+      "Cannot use async extension 'asyncValue' in generateSync()"
+    );
+  });
+
+  test("throws for async outputTransform", () => {
+    expect(() => generateSync(
+      { type: "string" },
+      {
+        outputTransform: async (value) => value,
+      }
+    )).toThrow("Cannot use async outputTransform in generateSync()");
+  });
+
+  test("createGeneratorSync increments seeds per call", () => {
+    const schema = { type: "integer", minimum: 1, maximum: 100 };
+    const generator = createGeneratorSync({ seed: 1 });
+
+    const first = generator.generate(schema);
+    const second = generator.generate(schema);
+
+    expect(typeof first).toBe("number");
+    expect(typeof second).toBe("number");
+    expect(first).not.toBe(second);
+  });
+
+  test("generates patternProperties keys that satisfy minProperties", () => {
+    const schema = {
+      type: "object",
+      patternProperties: {
+        "^hyb$": { type: "string" },
+      },
+      additionalProperties: false,
+      minProperties: 1,
+    } as const;
+
+    for (let seed = 1; seed <= 20; seed++) {
+      const result = generateSync(schema, { seed }) as Record<string, unknown>;
+      const keys = Object.keys(result);
+      expect(keys.length).toBeGreaterThan(0);
+      for (const key of keys) {
+        expect(/^hyb$/.test(key)).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `generateSync(schema, options?)` and `createGeneratorSync(options?)` as synchronous counterparts to `generate()`/`createGenerator()`, for schemas that do not need remote `$ref` resolution or async extensions/`outputTransform`.
- Sync mode resolves local refs from the registry and throws descriptive errors for anything genuinely async instead of silently returning a `Promise`: a `refResolver` option, a remote (non-local) `$ref`, a `jsf.define()` extension callback that returns a `Promise`, or an async `outputTransform`.
- `generate()` and `generateSync()` share a single generation core: `schema-walker.ts` and the `object`/`array`/`composition` generators are written once as `function*` generators. Two tiny drivers in the new `src/coroutine.ts` run the same generator body either as async (`walk`, awaits any yielded value) or sync (`walkSync`, throws if a yielded value is ever a `Promise`). This avoids hand-duplicating the ~1400-line generation algorithm across two files.

## Test plan
- [x] `bun run tsc -p tsconfig.build.json --noEmit` — clean
- [x] `bun test` — 613 passing, including a new parity test (`tests/unit/sync-async-parity.test.ts`) asserting byte-identical output between `generate()` and `generateSync()` across ~16 representative schemas (objects, arrays, `allOf`/`oneOf`/`anyOf`, `if`/`then`/`else`, `not`, local `$ref`+`$defs`, `patternProperties`, `dependencies`, `propAliases`, `pruneProperties`) and multiple seeds
- [x] `bun run build` — bundling and type declarations succeed

Closes #854
